### PR TITLE
Update the code to compute a linear trend cost and a few namelists

### DIFF
--- a/devel/iceshelf_icefront/input_lineartrend/data.ctrl
+++ b/devel/iceshelf_icefront/input_lineartrend/data.ctrl
@@ -1,0 +1,158 @@
+# *********************
+# ECCO controlvariables
+# *********************
+ &ctrl_nml
+#
+ doSinglePrecTapelev=.TRUE.,
+ ctrlSmoothCorrel2D=.TRUE.,
+ ctrlSmoothCorrel3D=.TRUE.,
+  ctrlUseGen=.TRUE.,
+#to start from given xx*00.data files
+# doinitxx = .FALSE.,
+# doMainUnpack = .FALSE.,
+#to start from given ecco_ctrl... files
+  doinitxx = .FALSE.,
+#
+#doPackDiag = .TRUE.,
+ forcingPrecond=1.,
+/
+
+#
+# *********************
+# names for ctrl_pack/unpack
+# *********************
+ &ctrl_packnames
+ /
+#
+# *********************
+# names for CTRL_GENARR, CTRL_GENTIM
+# *********************
+ &CTRL_NML_GENARR
+# xx_gentim2d_weight(1) = 'r2.watemp_var_tot_nomasking.data',
+# xx_gentim2d_file(1)='xx_atemp',
+# xx_gentim2d_period(1)=1209600.0,
+# xx_gentim2d_preproc(1,1)='WC01',
+# xx_gentim2d_preproc_i(1,1)=1,
+# xx_gentim2d_startdate1(1)=20021218,
+# xx_gentim2d_startdate2(1)=120000,
+# mult_gentim2d(1) = 1.,
+#
+# xx_gentim2d_weight(2) = 'r2.wprecip_var_nonseason_20150807_nomasking.data',
+# xx_gentim2d_file(2)='xx_precip',
+# xx_gentim2d_period(2)=1209600.0,
+# xx_gentim2d_preproc(1,2)='WC01',
+# xx_gentim2d_preproc_i(1,2)=1,
+# xx_gentim2d_startdate1(2)=20021218,
+# xx_gentim2d_startdate2(2)=120000,
+# mult_gentim2d(2) = 1.,
+#
+# xx_gentim2d_weight(3) = 'r2.wswdown_var_tot_nomasking.data',
+# xx_gentim2d_file(3)='xx_swdown',
+# xx_gentim2d_period(3)=1209600.0,
+# xx_gentim2d_preproc(1,3)='WC01',
+# xx_gentim2d_preproc_i(1,3)=1,
+# xx_gentim2d_startdate1(3)=20021218,
+# xx_gentim2d_startdate2(3)=120000,
+# mult_gentim2d(3) = 1.,
+#
+#
+# xx_gentim2d_weight(4) = 'r2.wlwdown_var_tot_nomasking.data',
+# xx_gentim2d_file(4)='xx_lwdown',
+# xx_gentim2d_period(4)=1209600.0,
+# xx_gentim2d_preproc(1,4)='WC01',
+# xx_gentim2d_preproc_i(1,4)=1,
+# xx_gentim2d_startdate1(4)=20021218,
+# xx_gentim2d_startdate2(4)=120000,
+# mult_gentim2d(4) = 1.,
+#
+# xx_gentim2d_weight(5) = 'r2.waqh_var_tot_nomasking.data',
+# xx_gentim2d_file(5)='xx_aqh',
+# xx_gentim2d_period(5)=1209600.0,
+# xx_gentim2d_preproc(1,5)='WC01',
+# xx_gentim2d_preproc_i(1,5)=1,
+# xx_gentim2d_startdate1(5)=20021218,
+# xx_gentim2d_startdate2(5)=120000,
+# mult_gentim2d(5) = 1.,
+#
+# xx_gentim2d_weight(6) = 'r2.wtauu_var_tot_nomasking.data',
+# xx_gentim2d_file(6)='xx_tauu',
+# xx_gentim2d_period(6)=1209600.0,
+# xx_gentim2d_preproc(1,6)='WC01',
+# xx_gentim2d_preproc_i(1,6)=1,
+# xx_gentim2d_startdate1(6)=20021218,
+# xx_gentim2d_startdate2(6)=120000,
+# mult_gentim2d(6) = 1.,
+#
+# xx_gentim2d_weight(7) = 'r2.wtauv_var_tot_nomasking.data',
+# xx_gentim2d_file(7)='xx_tauv',
+# xx_gentim2d_period(7)=1209600.0,
+# xx_gentim2d_preproc(1,7)='WC01',
+# xx_gentim2d_preproc_i(1,7)=1,
+# xx_gentim2d_startdate1(7)=20021218,
+# xx_gentim2d_startdate2(7)=120000,
+# mult_gentim2d(7) = 1.,
+#
+# xx_genarr2d_weight(1) = 'SSH_weights_nonseasonal_rms_areascaled_nomaskingSO.bin',
+# xx_genarr2d_file(1)='xx_etan',
+# xx_genarr2d_bounds(1:5,1)=-9.0,-8.9,8.9,9.0,0.,
+# xx_genarr2d_preproc(1,1)='WC01',
+# xx_genarr2d_preproc_i(1,1)=1,
+# mult_genarr2d(1) = 1.,
+#
+# xx_genarr3d_weight(1) = 'Theta_weights_nonseasonal_rmsv2_areascaled_nomaskingSO.bin',
+# xx_genarr3d_file(1)='xx_theta',
+# xx_genarr3d_bounds(1:5,1)=-2.0,-1.9,39.,40.,0.,
+# xx_genarr3d_preproc(1,1)='WC01',
+# xx_genarr3d_preproc_i(1,1)=1,
+# mult_genarr3d(1) = 1.,
+#
+# xx_genarr3d_weight(2) = 'Salt_weights_nonseasonal_rmsv2_areascaled_nomaskingSO.bin',
+# xx_genarr3d_file(2)='xx_salt',
+# xx_genarr3d_bounds(1:5,2)=20.,20.5,40.5,41.,0.,
+# xx_genarr3d_preproc(1,2)='WC01',
+# xx_genarr3d_preproc_i(1,2)=1,
+# mult_genarr3d(2) = 1.,
+#
+# xx_genarr3d_weight(3) = 'weight_kapgm_v4_areascaled.bin',
+# xx_genarr3d_file(3)='xx_kapgm',
+# xx_genarr3d_bounds(1:5,3)=1.E2,2.E2,0.9E4,1.E4,0.,
+# xx_genarr3d_preproc(1,3)='WC01',
+# xx_genarr3d_preproc_i(1,3)=1,
+# mult_genarr3d(3) = 1.,
+#
+# xx_genarr3d_weight(4) = 'weight_kapredi_v4_areascaled.bin',
+# xx_genarr3d_file(4)='xx_kapredi',
+# xx_genarr3d_bounds(1:5,4)=1.E2,2.E2,0.9E4,1.E4,0.,
+# xx_genarr3d_preproc(1,4)='WC01',
+# xx_genarr3d_preproc_i(1,4)=1,
+# mult_genarr3d(4) = 1.,
+#
+# xx_genarr3d_weight(5) = 'weight_diffkr_v4_areascaled.bin',
+# xx_genarr3d_file(5)='xx_diffkr',
+# xx_genarr3d_bounds(1:5,5)=1.E-6,2.E-6,4.E-4,5.E-4,0.,
+# xx_genarr3d_preproc(1,5)='WC01',
+# xx_genarr3d_preproc_i(1,5)=1,
+# mult_genarr3d(5) = 1.,
+#
+# xx_genarr3d_weight(6) = 'Uvel_weights_nonseasonal_rmsv2_areascaled_nomaskingSO.bin',
+# xx_genarr3d_file(6)='xx_uvel',
+# xx_genarr3d_bounds(1:5,6)=-3.,-2.9, 2.9,3.,0.,
+# xx_genarr3d_preproc(1,6)='WC01',
+# xx_genarr3d_preproc_i(1,6)=1,
+# mult_genarr3d(6) = 1.,
+#
+# xx_genarr3d_weight(7) = 'Vvel_weights_nonseasonal_rmsv2_areascaled_nomaskingSO.bin', 
+# xx_genarr3d_file(7)='xx_vvel',
+# xx_genarr3d_bounds(1:5,7)=-3.,-2.9, 2.9,3.,0.,
+# xx_genarr3d_preproc(1,7)='WC01',
+# xx_genarr3d_preproc_i(1,7)=1,
+# mult_genarr3d(7) = 1.,
+#
+ xx_genarr3d_weight(8) = 'w_shiTransCoeffT3d4_areascaled.bin',
+ xx_genarr3d_file(8)='xx_shiTransCoeffT',
+ xx_genarr3d_bounds(1:5,8)=1e-8,1.1e-8,0.9e-2,1e-2,0.,
+#xx_genarr3d_preproc(1,8)='WC01',
+#xx_genarr3d_preproc_i(1,8)=1,
+ mult_genarr3d(8) = 1.,
+
+ /

--- a/devel/iceshelf_icefront/input_lineartrend/data.ecco
+++ b/devel/iceshelf_icefront/input_lineartrend/data.ecco
@@ -1,0 +1,54 @@
+#
+#
+# ******************
+# ECCO cost function
+# ******************
+#
+ &ECCO_COST_NML
+#
+ data_errfile    = 'data.err',
+ temp0errfile     = 'Theta_sigma_smoothed_method_02_masked_merged_capped_areascaled.bin',
+ salt0errfile     = 'Salt_sigma_smoothed_method_02_masked_merged_capped_areascaled.bin',
+ cost_iprec  = 32,
+ cost_yftype = 'RL',
+#
+ /
+#
+ &ECCO_GENCOST_NML
+#
+  gencost_avgperiod(27)  = 'month',
+  gencost_barfile(27) = 'm_shifwflxmon',
+  gencost_datafile(27) = 'Rignot_meltrates_kgpersec_m2_72samerecv4_actual.bin',
+  gencost_errfile(27) = 'sigma_shiTransCoeffT_datacost4_actual_areascaled.bin',
+  gencost_name(27) = 'shifwflxmean',
+  gencost_spmin(27) = -999.,
+  gencost_spmax(27) = 999.,
+  gencost_spzero(27) = 0.,
+  gencost_preproc(1,27)='mean',
+  gencost_outputlevel(27)=1,
+  mult_gencost(27) = 1,
+#
+# linear trend cost (assuming data has zero trend)
+  gencost_avgperiod(28)  = 'month',
+  gencost_barfile(28) = 'm_shifwflxmon',
+  gencost_datafile(28) = 'zeros_2d',
+  gencost_errfile(28) = 'sigma_shiTransCoeffT_datacost4_actual_areascaled.bin',
+  gencost_name(28) = 'shifwflxtrend',
+  gencost_spmin(28) = -999.,
+  gencost_spmax(28) = 999.,
+  gencost_spzero(28) = -999.,
+  gencost_preproc(1,28)='trend',
+  # shifwflx_pinv_scaledby71mon.bin contains the 
+  # coefficients that are pre-computed for estimating 
+  # a linear trend problem. The coefficients have been 
+  # scaled by nrec-1 where nrec(=72) is the number of monthly 
+  # time records between 2003-2008. The size of 
+  # shifwflx_pinv_scaledby71mon.bin is 72x4 = 288 bytes
+  # for 72 single precision numbers. 
+  # The linear trend is the sum over the time records of the 
+  # product of the model melt rate and the coefficients. 
+  gencost_preproc_c(1,28)='shifwflx_pinv_scaledby71mon.bin',
+  gencost_outputlevel(28)=1,
+  mult_gencost(28) = 1,
+ /
+#


### PR DESCRIPTION
Update the code to compute a linear trend cost. Also create a new directory called input_lineartrend to include the linear trend constraint for the melt rate. The weights for the transfer coefficients and for the melt rate costs are updated. 