### PR TITLE
Turn on selectAddFluid in the namelist file data to add mass from the…

### DIFF
--- a/devel/iceshelf_icefront/input/data
+++ b/devel/iceshelf_icefront/input/data
@@ -62,6 +62,7 @@
  useJamartWetPoints=.TRUE.,
  readBinaryPrec=32,
  writeBinaryPrec=32,
+ selectAddFluid=1,
  debugLevel=1,
  /
 


### PR DESCRIPTION
Set selectAddFluid=1 in the namelist file "data" to add the extra mass from the melt water. However, this requires the pickup.*.data file contains a 3d field called 'AddMass '. 

To satisfy this requirement, one could manually modify the pickup.*.data file by adding this extra field with the values all set to zero. For v4r3, this 3d double-precision field would be added between 'GvNm2   ' and 'EtaN    '. The pickup.*.meta should also be modified accordingly. Below is an example of one pickup.*.meta file before and after the modification:
**Before:**
 nDims = [   2 ];
 dimList = [
    90,    1,   90,
  1170,    1, 1170
 ];
 dataprec = [ 'float64' ];
 nrecords = [   403 ];
 timeStepNumber = [      96420 ];
 timeInterval = [  3.471120000000E+08 ];
 nFlds = [   11 ];
 fldList = {
 'Uvel    ' 'Vvel    ' 'Theta   ' 'Salt    ' 'GuNm1   ' 'GuNm2   ' 'GvNm1   ' 'GvNm2   ' 'EtaN    ' 'dEtaHdt ' 'EtaH    '
 };

**After:**
 nDims = [   2 ];
 dimList = [
    90,    1,   90,
  1170,    1, 1170
 ];
 dataprec = [ 'float64' ];
 nrecords = [   453 ];
 timeStepNumber = [      96420 ];
 timeInterval = [  3.471120000000E+08 ];
 nFlds = [   12 ];
 fldList = {
 'Uvel    ' 'Vvel    ' 'Theta   ' 'Salt    ' 'GuNm1   ' 'GuNm2   ' 'GvNm1   ' 'GvNm2   ' 'AddMass ' 'EtaN    ' 'dEtaHdt ' 'EtaH    '
 };
