### PR TITLE
Reduce recomputation in shelfice and turn on two CPP options

### DIFF
--- a/devel/V4r5_devel/code/SALT_PLUME_OPTIONS.h
+++ b/devel/V4r5_devel/code/SALT_PLUME_OPTIONS.h
@@ -1,0 +1,27 @@
+C CPP options file for salt_plume package
+C Use this file for selecting options within the salt_plume package
+
+#ifndef SALT_PLUME_OPTIONS_H
+#define SALT_PLUME_OPTIONS_H
+#include "PACKAGES_CONFIG.h"
+#include "CPP_OPTIONS.h"
+
+#ifdef ALLOW_SALT_PLUME
+C Place CPP define/undef flag here
+
+C SALT_PLUME_IN_LEADS
+C   Motivation: As ice concentration AREA -> 1, leads occur -> ice
+C     production is no longer uniform in grid box -> assumptions
+C     which motivate KPP no longer holds -> treat overturn more
+C     realistic with this flag.
+C   if defined: Activate pkg/salt_plume only when seaice AREA exceeds
+C               a certain value representative of lead opening AND only
+C               if seaice growth dh is from atmospheric cooling.
+C   if undefined: Activate pkg/salt_plume whenever seaice forms.
+C                 This is the default of pkg/salt_plume.
+#define SALT_PLUME_IN_LEADS
+#undef SALT_PLUME_SPLIT_BASIN
+#undef SALT_PLUME_VOLUME
+
+#endif /* ALLOW_SALT_PLUME */
+#endif /* SALT_PLUME_OPTIONS_H */

--- a/devel/V4r5_devel/code/SEAICE_OPTIONS.h
+++ b/devel/V4r5_devel/code/SEAICE_OPTIONS.h
@@ -18,6 +18,8 @@ C     *==========================================================*
 #define ALLOW_SEAICE_GROWTH_ADX
 C     Package-specific Options & Macros go here
 
+#define ALLOW_SEAICE_FLOODING
+
 C--   Write "text-plots" of certain fields in STDOUT for debugging.
 #undef SEAICE_DEBUG
 

--- a/devel/V4r5_devel/code/SHELFICE.h
+++ b/devel/V4r5_devel/code/SHELFICE.h
@@ -200,6 +200,17 @@ C      mask3dICF: 3d ice-front mask
       _RS mask2dICF  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy)
       _RS mask3dICF  (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr,nSx,nSy)
 
+C ow - 07/23/2020
+C ow - CURI_ARR, CURJ_AA, 
+C      CURI_ARR: i-index for neighboring ice-front points
+C      CURJ_ARR: j-index for neighboring ice-front points
+C      icefrontwidth_arr: ice-front width in meters
+      COMMON /SHELFICE_ICEFRONT_I/CURI_ARR, CURJ_ARR
+      INTEGER CURI_ARR(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy,4) 
+      INTEGER CURJ_ARR(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy,4) 
+      COMMON /SHELFICE_ICEFRONT_R/icefrontwidth_arr
+      _RL icefrontwidth_arr(1-OLx:sNx+OLx,1-OLy:sNy+OLy,nSx,nSy,4) 
+
       LOGICAL SHELFICEisOn
       LOGICAL useISOMIPTD
       LOGICAL SHELFICEconserve

--- a/devel/V4r5_devel/code/seaice_growth_adx.F
+++ b/devel/V4r5_devel/code/seaice_growth_adx.F
@@ -1232,6 +1232,23 @@ CADJ STORE HSNOW(:,:,bi,bj) = comlev1_bibj,key=iicekey,byte=isbyte
 #endif /* ALLOW_AUTODIFF_TAMC */
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
 
+#ifdef ALLOW_SEAICE_FLOODING
+        IF(SEAICEuseFlooding) THEN
+         DO J=1,sNy
+           DO I=1,sNx
+ 
+            tmpscal0 = (HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
+     &               +HEFF(I,J,bi,bj)*SEAICE_rhoIce)*recip_rhoConst
+            d_HEFFbyFlood(I,J) = MAX(tmpscal0 - HEFF(I,J,bi,bj),0. _d 0)
+                     HEFF(I,J,bi,bj)=HEFF(I,J,bi,bj)+d_HEFFbyFlood(I,J)
+                     HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj)-
+     &               d_HEFFbyFlood(I,J)*ICE2SNOW
+           ENDDO
+         ENDDO
+c SEAICEuseFlooding
+        ENDIF
+c ALLOW_SEAICE_FLOODING
+#endif
         DO J=1,sNy
           DO I=1,sNx
 
@@ -1243,19 +1260,19 @@ c         THE EFFECTIVE SHORTWAVE HEATING RATE
 #else
             QSW(I,J,bi,bj) = 0. _d 0
 #endif
-#ifdef ALLOW_SEAICE_FLOODING
-        IF(SEAICEuseFlooding) THEN
-
-           tmpscal0 = (HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
-     &              +HEFF(I,J,bi,bj)*SEAICE_rhoIce)*recip_rhoConst
-          d_HEFFbyFlood(I,J) = MAX(tmpscal0 - HEFF(I,J,bi,bj), 0. _d 0)
-                      HEFF(I,J,bi,bj)=HEFF(I,J,bi,bj)+d_HEFFbyFlood(I,J)
-                      HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj)-
-     &                 d_HEFFbyFlood(I,J)*ICE2SNOW
-c SEAICEuseFlooding
-           ENDIF
-c ALLOW_SEAICE_FLOODING
-#endif
+C#ifdef ALLOW_SEAICE_FLOODING
+C        IF(SEAICEuseFlooding) THEN
+C
+C           tmpscal0 = (HSNOW(I,J,bi,bj)*SEAICE_rhoSnow
+C     &              +HEFF(I,J,bi,bj)*SEAICE_rhoIce)*recip_rhoConst
+C          d_HEFFbyFlood(I,J) = MAX(tmpscal0 - HEFF(I,J,bi,bj), 0. _d 0)
+C                      HEFF(I,J,bi,bj)=HEFF(I,J,bi,bj)+d_HEFFbyFlood(I,J)
+C                      HSNOW(I,J,bi,bj) = HSNOW(I,J,bi,bj)-
+C     &                 d_HEFFbyFlood(I,J)*ICE2SNOW
+Cc SEAICEuseFlooding
+C           ENDIF
+Cc ALLOW_SEAICE_FLOODING
+C#endif
 
 c           The actual ice volume change over the time step
             ActualNewTotalVolumeChange(I,J) =

--- a/devel/V4r5_devel/code/shelfice_init_fixed.F
+++ b/devel/V4r5_devel/code/shelfice_init_fixed.F
@@ -156,6 +156,17 @@ C ow - the vertical, then mask2dSHI at i,j is one.
           ENDDO
          ENDDO
         ENDDO
+
+        DO J = 1-OLy,sNy+OLy
+          DO I = 1-OLx,sNx+OLx
+             DO SI = 1,4
+                CURI_ARR(I,J,bi,bj,SI) = -9999
+                CURJ_ARR(I,J,bi,bj,SI) = -9999
+                icefrontwidth_arr(I,J,bi,bj,SI) = 0. _d 0
+             ENDDO /* SI */
+          ENDDO /* I */
+        ENDDO /* J */
+
 C       DO k=1,Nr
 C        DO j=1-OLy,sNy+OLy
 C         DO i=1-OLx,sNx+OLx
@@ -322,6 +333,11 @@ C--   Looking to south
                   
                       iceFrontWidth     = dxG(I,J,bi,bj)
                     endif
+
+                    CURI_ARR(I,J,bi,bj,SI) = CURI
+                    CURJ_ARR(I,J,bi,bj,SI) = CURJ
+                    iceFrontWidth_arr(I,J,bi,bj,SI) = iceFrontWidth
+
                     
 C--                 cell depth describes the average distance 
 C--                 perpendicular to the ice front fact

--- a/devel/V4r5_devel/code/shelfice_thermodynamics.F
+++ b/devel/V4r5_devel/code/shelfice_thermodynamics.F
@@ -175,34 +175,12 @@ C--   Loop around the four laterally neighboring cells of the ice front.
 C--   If any neighboring points has wet volume in contact with the ice
 C--   front at (I,J) then calculate ice-ocean exchanges.  
 C--   The four laterally neighboring point are at (CURI,CURJ)
+
                   DO SI = 1,4
-                    IF     (SI .EQ. 1) THEN
-C--   Looking to right                  
-                      CURI = I+1
-                      CURJ = J
+                     CURI=CURI_ARR(I,J,bi,bj,SI) 
+                     CURJ=CURJ_ARR(I,J,bi,bj,SI)
+                     iceFrontWidth=iceFrontWidth_arr(I,J,bi,bj,SI)
 
-                      iceFrontWidth     = dyG(I+1,J,bi,bj)
-                      
-                    ELSEIF (SI .EQ. 2) THEN
-C--   Looking to LEFT                  
-                      CURI = I-1
-                      CURJ = J
-
-                      iceFrontWidth     = dyG(I,J,bi,bj)
-                    ELSEIF (SI .EQ. 3) THEN
-C--   Looking to NORTH                                    
-                      CURI = I
-                      CURJ = J+1
-
-                      iceFrontWidth     = dxG(I,J+1,bi,bj)
-                    ELSEIF (SI .EQ. 4) THEN
-C--   Looking to south                   
-                      CURI = I
-                      CURJ = J-1
-                  
-                      iceFrontWidth     = dxG(I,J,bi,bj)
-                    endif
-                    
 C--                 cell depth describes the average distance 
 C--                 perpendicular to the ice front fact
 


### PR DESCRIPTION
The pull request contains the following two changes:

1) Get rid of some recomputations in shelfice_thermodynamics.F by not calculating CURI and CURJ in shelfice_thermodynamics.F. Instead, two arrays CURI_ARR and CURJ_ARR are created and initialized with CURI and CURJ in shelfice_init_fixed.F. CURI and CURJ in shelfice_thermodynamics.F are then assigned with the corresponding CURI_ARR and CURJ_ARR.

2) Turn on two CPP options:
In SEAICE_OPTIONS.h
#define ALLOW_SEAICE_FLOODING

In SALT_PLUME_OPTIONS.h
#define SALT_PLUME_IN_LEADS
