### PR TITLE
Restore stratification inside ice cavities

### DIFF
--- a/devel/V4r5_devel/code/ggl90_calc.F
+++ b/devel/V4r5_devel/code/ggl90_calc.F
@@ -1,0 +1,949 @@
+#include "GGL90_OPTIONS.h"
+
+CBOP
+C !ROUTINE: GGL90_CALC
+
+C !INTERFACE: ======================================================
+      SUBROUTINE GGL90_CALC(
+     I                 bi, bj, sigmaR, myTime, myIter, myThid )
+
+C !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SUBROUTINE GGL90_CALC                                    |
+C     | o Compute all GGL90 fields defined in GGL90.h            |
+C     *==========================================================*
+C     | Equation numbers refer to                                |
+C     | Gaspar et al. (1990), JGR 95 (C9), pp 16,179             |
+C     | Some parts of the implementation follow Blanke and       |
+C     | Delecuse (1993), JPO, and OPA code, in particular the    |
+C     | computation of the                                       |
+C     | mixing length = max(min(lk,depth),lkmin)                 |
+C     *==========================================================*
+
+C global parameters updated by ggl90_calc
+C     GGL90TKE     :: sub-grid turbulent kinetic energy          (m^2/s^2)
+C     GGL90viscAz  :: GGL90 eddy viscosity coefficient             (m^2/s)
+C     GGL90diffKzT :: GGL90 diffusion coefficient for temperature  (m^2/s)
+C \ev
+
+C !USES: ============================================================
+      IMPLICIT NONE
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "DYNVARS.h"
+#include "FFIELDS.h"
+#include "GRID.h"
+#include "GGL90.h"
+#ifdef ALLOW_SHELFICE
+#include "SHELFICE.h"
+#endif 
+C !INPUT PARAMETERS: ===================================================
+C Routine arguments
+C     bi, bj :: Current tile indices
+C     sigmaR :: Vertical gradient of iso-neutral density
+C     myTime :: Current time in simulation
+C     myIter :: Current time-step number
+C     myThid :: My Thread Id number
+      INTEGER bi, bj
+      _RL     sigmaR(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
+
+#ifdef ALLOW_GGL90
+
+C !LOCAL VARIABLES: ====================================================
+C Local constants
+C     iMin,iMax,jMin,jMax :: index boundaries of computation domain
+C     i, j, k, kp1,km1 :: array computation indices
+C     kSurf, kBottom   :: vertical indices of domain boundaries
+C     hFac/hFacI       :: fractional thickness of W-cell
+C     explDissFac      :: explicit Dissipation Factor (in [0-1])
+C     implDissFac      :: implicit Dissipation Factor (in [0-1])
+C     uStarSquare      :: square of friction velocity
+C     verticalShear    :: (squared) vertical shear of horizontal velocity
+C     Nsquare          :: squared buoyancy freqency
+C     RiNumber         :: local Richardson number
+C     KappaM           :: (local) viscosity parameter (eq.10)
+C     KappaH           :: (local) diffusivity parameter for temperature (eq.11)
+C     KappaE           :: (local) diffusivity parameter for TKE (eq.15)
+C     TKEdissipation   :: dissipation of TKE
+C     GGL90mixingLength:: mixing length of scheme following Banke+Delecuse
+C         rMixingLength:: inverse of mixing length
+C     totalDepth       :: thickness of water column (inverse of recip_Rcol)
+C     TKEPrandtlNumber :: here, an empirical function of the Richardson number
+      INTEGER iMin ,iMax ,jMin ,jMax
+      INTEGER i, j, k, kp1, km1, kSurf, kBottom
+#ifdef ALLOW_SHELFICE   
+      INTEGER ktmp
+      _RL     explDissFacSI, implDissFacSI
+#endif
+      _RL     explDissFac, implDissFac
+      _RL     uStarSquare
+      _RL     verticalShear(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL     KappaM(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL     KappaH
+c     _RL     Nsquare
+      _RL     Nsquare(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL     deltaTggl90
+c     _RL     SQRTTKE
+      _RL     SQRTTKE(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL     RiNumber
+#ifdef ALLOW_GGL90_IDEMIX
+      _RL     IDEMIX_RiNumber
+#endif
+      _RL     TKEdissipation
+      _RL     tempU, tempUp, tempV, tempVp, prTemp
+      _RL     MaxLength, tmpmlx, tmpVisc
+      _RL     TKEPrandtlNumber (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL     GGL90mixingLength(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL     rMixingLength    (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL     mxLength_Dn      (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL     KappaE           (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL     totalDepth       (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL     GGL90visctmp     (1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+#ifdef ALLOW_DIAGNOSTICS
+      _RL     surf_flx_tke     (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+#endif /* ALLOW_DIAGNOSTICS */
+C     hFac(I)  :: fractional thickness of W-cell
+      _RL       hFac
+#ifdef ALLOW_GGL90_IDEMIX
+      _RL       hFacI(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+#endif /* ALLOW_GGL90_IDEMIX */
+      _RL recip_hFacI(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+C-    tri-diagonal matrix
+      _RL     a3d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL     b3d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL     c3d(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      INTEGER errCode
+#ifdef ALLOW_GGL90_HORIZDIFF
+C     xA, yA   :: area of lateral faces
+C     dfx, dfy :: diffusive flux across lateral faces
+C     gTKE     :: right hand side of diffusion equation
+      _RL     xA (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL     yA (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL     dfx(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL     dfy(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL    gTKE(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+#endif /* ALLOW_GGL90_HORIZDIFF */
+#ifdef ALLOW_GGL90_SMOOTH
+      _RL p4, p8, p16
+#endif
+CEOP
+
+      PARAMETER( iMin = 2-OLx, iMax = sNx+OLx-1 )
+      PARAMETER( jMin = 2-OLy, jMax = sNy+OLy-1 )
+#ifdef ALLOW_GGL90_SMOOTH
+      p4  = 0.25   _d 0
+      p8  = 0.125  _d 0
+      p16 = 0.0625 _d 0
+#endif
+
+C     set separate time step (should be deltaTtracer)
+      deltaTggl90 = dTtracerLev(1)
+
+      kSurf = 1
+C     explicit/implicit timestepping weights for dissipation
+      explDissFac = 0. _d 0
+      implDissFac = 1. _d 0 - explDissFac
+
+#ifdef ALLOW_SHELFICE   
+      explDissFacSI = 0.5 _d 0
+      implDissFacSI = 1. _d 0 - explDissFacSI
+#endif
+
+C     For nonlinear free surface and especially with r*-coordinates, the
+C     hFacs change every timestep, so we need to update them here in the
+C     case of using IDEMIX.
+       DO K=1,Nr
+        Km1 = MAX(K-1,1)
+        DO j=1-OLy,sNy+OLy
+         DO i=1-OLx,sNx+OLx
+          hFac =
+     &         MIN(.5 _d 0,_hFacC(i,j,km1,bi,bj) ) +
+     &         MIN(.5 _d 0,_hFacC(i,j,k  ,bi,bj) )
+          recip_hFacI(I,J,K)=0. _d 0
+          IF ( hFac .NE. 0. _d 0 )
+     &         recip_hFacI(I,J,K)=1. _d 0/hFac
+#ifdef ALLOW_GGL90_IDEMIX
+          hFacI(i,j,k) = hFac
+#endif /* ALLOW_GGL90_IDEMIX */
+         ENDDO
+        ENDDO
+       ENDDO
+
+C     Initialize local fields
+      DO k = 1, Nr
+       DO j=1-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+         rMixingLength(i,j,k)     = 0. _d 0
+         mxLength_Dn(i,j,k)       = 0. _d 0
+         GGL90visctmp(i,j,k)      = 0. _d 0
+         KappaE(i,j,k)            = 0. _d 0
+         TKEPrandtlNumber(i,j,k)  = 1. _d 0
+         GGL90mixingLength(i,j,k) = GGL90mixingLengthMin
+         GGL90visctmp(i,j,k)      = 0. _d 0
+#ifndef SOLVE_DIAGONAL_LOWMEMORY
+         a3d(i,j,k) = 0. _d 0
+         b3d(i,j,k) = 1. _d 0
+         c3d(i,j,k) = 0. _d 0
+#endif
+         Nsquare(i,j,k) = 0. _d 0
+         SQRTTKE(i,j,k) = 0. _d 0
+        ENDDO
+       ENDDO
+      ENDDO
+      DO j=1-OLy,sNy+OLy
+       DO i=1-OLx,sNx+OLx
+        KappaM(i,j)        = 0. _d 0
+        verticalShear(i,j) = 0. _d 0
+        totalDepth(i,j)    = Ro_surf(i,j,bi,bj) - R_low(i,j,bi,bj)
+
+c        print  '(A,3i4,1(1x,1P3E15.6))',
+c     &   'GGLC kTopC totalDepth ', i,j,kTopC(i,j,bi,bj),
+c     &   totalDepth(i,j)
+
+
+        rMixingLength(i,j,1) = 0. _d 0
+        mxLength_Dn(i,j,1) = GGL90mixingLengthMin
+        SQRTTKE(i,j,1) = SQRT( GGL90TKE(i,j,1,bi,bj) )
+#ifdef ALLOW_GGL90_HORIZDIFF
+        xA(i,j)  = 0. _d 0
+        yA(i,j)  = 0. _d 0
+        dfx(i,j) = 0. _d 0
+        dfy(i,j) = 0. _d 0
+        gTKE(i,j) = 0. _d 0
+#endif /* ALLOW_GGL90_HORIZDIFF */
+       ENDDO
+      ENDDO
+
+#ifdef ALLOW_GGL90_IDEMIX
+      IF ( useIDEMIX) CALL GGL90_IDEMIX(
+     &   bi, bj, hFacI, recip_hFacI, sigmaR, myTime, myIter, myThid )
+#endif /* ALLOW_GGL90_IDEMIX */
+
+      DO k = 2, Nr
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+         SQRTTKE(i,j,k)=SQRT( GGL90TKE(i,j,k,bi,bj) )
+
+C     buoyancy frequency
+         Nsquare(i,j,k) = gravity*gravitySign*recip_rhoConst
+     &                  * sigmaR(i,j,k)
+C     vertical shear term (dU/dz)^2+(dV/dz)^2 is computed later
+C     to save some memory
+C     mixing length
+         GGL90mixingLength(i,j,k) = SQRTTWO *
+     &        SQRTTKE(i,j,k)/SQRT( MAX(Nsquare(i,j,k),GGL90eps) )
+
+#ifdef ALLOW_SHELFICE
+        if (k .LT. kTopC(i,j,bi,bj)) THEN
+         SQRTTKE(i,j,k) = 0.0 _d 0
+         Nsquare(i,j,k) = 0.0 _d 0
+         GGL90mixingLength(i,j,k) = 0.0 _d 0
+        endif
+#endif
+        ENDDO
+       ENDDO
+      ENDDO
+
+C- ensure mixing between first and second level
+      IF (mxlSurfFlag) THEN
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+
+#ifdef ALLOW_SHELFICE
+         ktmp = kTopC(i,j,bi,bj)
+         if (ktmp .EQ. 0) THEN
+           GGL90mixingLength(i,j,2)=drF(1)
+         ELSE
+           GGL90mixingLength(i,j,ktmp+1)=drF(ktmp)
+         ENDIF
+#else
+         GGL90mixingLength(i,j,2)=drF(1)
+#endif
+        ENDDO
+       ENDDO
+      ENDIF
+
+C--   Impose upper and lower bound for mixing length
+C--   Impose minimum mixing length to avoid division by zero
+      IF ( mxlMaxFlag .EQ. 0 ) THEN
+
+       DO k=2,Nr
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          MaxLength=totalDepth(i,j)
+          GGL90mixingLength(i,j,k) = MIN(GGL90mixingLength(i,j,k),
+     &                                   MaxLength)
+         ENDDO
+        ENDDO
+       ENDDO
+
+       DO k=2,Nr
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          GGL90mixingLength(i,j,k) = MAX(GGL90mixingLength(i,j,k),
+     &                                   GGL90mixingLengthMin)
+          rMixingLength(i,j,k) = 1. _d 0 / GGL90mixingLength(i,j,k)
+         ENDDO
+        ENDDO
+       ENDDO
+
+      ELSEIF ( mxlMaxFlag .EQ. 1 ) THEN
+
+       DO k=2,Nr
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          MaxLength=MIN(Ro_surf(i,j,bi,bj)-rF(k),rF(k)-R_low(i,j,bi,bj))
+c         MaxLength=MAX(MaxLength,20. _d 0)
+          GGL90mixingLength(i,j,k) = MIN(GGL90mixingLength(i,j,k),
+     &                                   MaxLength)
+         ENDDO
+        ENDDO
+       ENDDO
+
+       DO k=2,Nr
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          GGL90mixingLength(i,j,k) = MAX(GGL90mixingLength(i,j,k),
+     &                                   GGL90mixingLengthMin)
+          rMixingLength(i,j,k) = 1. _d 0 / GGL90mixingLength(i,j,k)
+         ENDDO
+        ENDDO
+       ENDDO
+
+      ELSEIF ( mxlMaxFlag .EQ. 2 ) THEN
+
+       DO k=2,Nr
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          GGL90mixingLength(i,j,k) = MIN(GGL90mixingLength(i,j,k),
+     &        GGL90mixingLength(i,j,k-1)+drF(k-1))
+         ENDDO
+        ENDDO
+       ENDDO
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+          GGL90mixingLength(i,j,Nr) = MIN(GGL90mixingLength(i,j,Nr),
+     &       GGL90mixingLengthMin+drF(Nr))
+        ENDDO
+       ENDDO
+       DO k=Nr-1,2,-1
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          GGL90mixingLength(i,j,k) = MIN(GGL90mixingLength(i,j,k),
+     &        GGL90mixingLength(i,j,k+1)+drF(k))
+         ENDDO
+        ENDDO
+       ENDDO
+
+       DO k=2,Nr
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          GGL90mixingLength(i,j,k) = MAX(GGL90mixingLength(i,j,k),
+     &                                   GGL90mixingLengthMin)
+          rMixingLength(i,j,k) = 1. _d 0 / GGL90mixingLength(i,j,k)
+         ENDDO
+        ENDDO
+       ENDDO
+
+      ELSEIF ( mxlMaxFlag .EQ. 3 ) THEN
+
+       DO k=2,Nr
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          mxLength_Dn(i,j,k) = MIN(GGL90mixingLength(i,j,k),
+     &        mxLength_Dn(i,j,k-1)+drF(k-1))
+         ENDDO
+        ENDDO
+       ENDDO
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+          GGL90mixingLength(i,j,Nr) = MIN(GGL90mixingLength(i,j,Nr),
+     &       GGL90mixingLengthMin+drF(Nr))
+        ENDDO
+       ENDDO
+       DO k=Nr-1,2,-1
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          GGL90mixingLength(i,j,k) = MIN(GGL90mixingLength(i,j,k),
+     &        GGL90mixingLength(i,j,k+1)+drF(k))
+         ENDDO
+        ENDDO
+       ENDDO
+
+       DO k=2,Nr
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          GGL90mixingLength(i,j,k) = MIN(GGL90mixingLength(i,j,k),
+     &                                  mxLength_Dn(i,j,k))
+          tmpmlx = SQRT( GGL90mixingLength(i,j,k)*mxLength_Dn(i,j,k) )
+          tmpmlx = MAX( tmpmlx, GGL90mixingLengthMin)
+          rMixingLength(i,j,k) = 1. _d 0 / tmpmlx
+         ENDDO
+        ENDDO
+       ENDDO
+
+      ELSE
+       STOP 'GGL90_CALC: Wrong mxlMaxFlag (mixing length limit)'
+      ENDIF
+
+C     start "proper" k-loop (the code above was moved out and up to
+C     implemement various mixing parameters efficiently)
+      DO k=2,Nr
+       km1 = k-1
+
+#ifdef ALLOW_GGL90_HORIZDIFF
+      IF ( GGL90diffTKEh .GT. 0. _d 0 ) THEN
+C     horizontal diffusion of TKE (requires an exchange in
+C      do_fields_blocking_exchanges)
+C     common factors
+        DO j=1-OLy,sNy+OLy
+         DO i=1-OLx,sNx+OLx
+          xA(i,j) = _dyG(i,j,bi,bj)*drC(k)*
+     &                 (min(.5 _d 0,_hFacW(i,j,k-1,bi,bj) ) +
+     &                  min(.5 _d 0,_hFacW(i,j,k  ,bi,bj) ) )
+          yA(i,j) = _dxG(i,j,bi,bj)*drC(k)*
+     &                 (min(.5 _d 0,_hFacS(i,j,k-1,bi,bj) ) +
+     &                  min(.5 _d 0,_hFacS(i,j,k  ,bi,bj) ) )
+         ENDDO
+        ENDDO
+C     Compute diffusive fluxes
+C     ... across x-faces
+        DO j=1-OLy,sNy+OLy
+         dfx(1-OLx,j)=0. _d 0
+         DO i=1-OLx+1,sNx+OLx
+          dfx(i,j) = -GGL90diffTKEh*xA(i,j)
+     &      *_recip_dxC(i,j,bi,bj)
+     &      *(GGL90TKE(i,j,k,bi,bj)-GGL90TKE(i-1,j,k,bi,bj))
+#ifdef ISOTROPIC_COS_SCALING
+     &      *CosFacU(j,bi,bj)
+#endif /* ISOTROPIC_COS_SCALING */
+         ENDDO
+        ENDDO
+C     ... across y-faces
+        DO i=1-OLx,sNx+OLx
+         dfy(i,1-OLy)=0. _d 0
+        ENDDO
+        DO j=1-OLy+1,sNy+OLy
+         DO i=1-OLx,sNx+OLx
+          dfy(i,j) = -GGL90diffTKEh*yA(i,j)
+     &      *_recip_dyC(i,j,bi,bj)
+     &      *(GGL90TKE(i,j,k,bi,bj)-GGL90TKE(i,j-1,k,bi,bj))
+#ifdef ISOTROPIC_COS_SCALING
+     &      *CosFacV(j,bi,bj)
+#endif /* ISOTROPIC_COS_SCALING */
+         ENDDO
+        ENDDO
+C     Compute divergence of fluxes
+        DO j=1-OLy,sNy+OLy-1
+         DO i=1-OLx,sNx+OLx-1
+          gTKE(i,j) = -recip_drC(k)*recip_rA(i,j,bi,bj)
+     &         *recip_hFacI(i,j,k)
+     &         *((dfx(i+1,j)-dfx(i,j))
+     &         + (dfy(i,j+1)-dfy(i,j)) )
+         ENDDO
+        ENDDO
+C     end if GGL90diffTKEh .eq. 0.
+       ENDIF
+#endif /* ALLOW_GGL90_HORIZDIFF */
+
+C     viscosity and diffusivity
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+         KappaM(i,j) = GGL90ck*GGL90mixingLength(i,j,k)*SQRTTKE(i,j,k)
+         GGL90visctmp(i,j,k) = MAX(KappaM(i,j),diffKrNrS(k))
+     &                            * maskC(i,j,k,bi,bj)
+C        note: storing GGL90visctmp like this, and using it later to compute
+C              GGL9rdiffKr etc. is robust in case of smoothing (e.g. see OPA)
+         KappaM(i,j) = MAX(KappaM(i,j),viscArNr(k)) * maskC(i,j,k,bi,bj)
+        ENDDO
+       ENDDO
+
+C     compute vertical shear (dU/dz)^2+(dV/dz)^2
+       IF ( calcMeanVertShear ) THEN
+C     by averaging (@ grid-cell center) the 4 vertical shear compon @ U,V pos.
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          tempU  = ( uVel( i ,j,km1,bi,bj) - uVel( i ,j,k,bi,bj) )
+          tempUp = ( uVel(i+1,j,km1,bi,bj) - uVel(i+1,j,k,bi,bj) )
+          tempV  = ( vVel(i, j ,km1,bi,bj) - vVel(i, j ,k,bi,bj) )
+          tempVp = ( vVel(i,j+1,km1,bi,bj) - vVel(i,j+1,k,bi,bj) )
+          verticalShear(i,j) = (
+     &                 ( tempU*tempU + tempUp*tempUp )*halfRL
+     &               + ( tempV*tempV + tempVp*tempVp )*halfRL
+     &                         )*recip_drC(k)*recip_drC(k)
+
+         ENDDO
+        ENDDO
+       ELSE
+C     from the averaged flow at grid-cell center (2 compon x 2 pos.)
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          tempU = ( ( uVel(i,j,km1,bi,bj) + uVel(i+1,j,km1,bi,bj) )
+     &             -( uVel(i,j,k  ,bi,bj) + uVel(i+1,j,k  ,bi,bj) )
+     &            )*halfRL*recip_drC(k)
+          tempV = ( ( vVel(i,j,km1,bi,bj) + vVel(i,j+1,km1,bi,bj) )
+     &             -( vVel(i,j,k  ,bi,bj) + vVel(i,j+1,k  ,bi,bj) )
+     &            )*halfRL*recip_drC(k)
+          verticalShear(i,j) = tempU*tempU + tempV*tempV
+         ENDDO
+        ENDDO
+       ENDIF
+
+#ifdef ALLOW_SHELFICE
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+           IF (k .EQ. kTopC(i,j,bi,bj)) THEN
+            IF ( debugLevel.GE.debLevE )
+     &        print '(A,3i4,3(1x,1P3E15.6))',
+     &              'GGLVS0 i j k vS ', i,j,k,
+     &                verticalShear(i,j)    
+
+             verticalShear(i,j) = 0.0 _d 0
+            IF ( debugLevel.GE.debLevE )
+     &        print '(A,3i4,3(1x,1P3E15.6))',
+     &              'GGLVS1 i j k vS ', i,j,k,
+     &                verticalShear(i,j)    
+           ELSEIF ((kTopC(i,j,bi,bj) .GT. 0) .AND.
+     &             (maskC(i,j,k,bi,bj) .GT. 0)) THEN
+            IF ( debugLevel.GE.debLevE )
+     &        print '(A,3i4,3(1x,1P3E15.6))',
+     &              'GGLVSS i j k vS ', i,j,k,
+     &                verticalShear(i,j)    
+           ENDIF 
+         ENDDO
+        ENDDO
+#endif
+
+C     compute Prandtl number (always greater than 0)
+#ifdef ALLOW_GGL90_IDEMIX
+       IF ( useIDEMIX ) THEN
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+C     account for partical cell factor in vertical shear:
+          verticalShear(i,j) = verticalShear(i,j)
+     &                       * recip_hFacI(i,j,k)*recip_hFacI(i,j,k)
+          RiNumber = MAX(Nsquare(i,j,k),0. _d 0)
+     &         /(verticalShear(i,j)+GGL90eps)
+CML         IDEMIX_RiNumber = 1./GGL90eps
+          IDEMIX_RiNumber = MAX( KappaM(i,j)*Nsquare(i,j,k), 0. _d 0)/
+     &     (GGL90eps+IDEMIX_tau_d(i,j,k,bi,bj)*IDEMIX_E(i,j,k,bi,bj)**2)
+          prTemp         = MIN(5.*RiNumber, 6.6 _d 0*IDEMIX_RiNumber)
+          TKEPrandtlNumber(i,j,k) = MIN(10. _d 0,prTemp)
+          TKEPrandtlNumber(i,j,k) = MAX( 1. _d 0,TKEPrandtlNumber(i,j,k))
+         ENDDO
+        ENDDO
+       ELSE
+#endif /* ALLOW_GGL90_IDEMIX */
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          RiNumber = MAX(Nsquare(i,j,k),0. _d 0)
+     &         /(verticalShear(i,j)+GGL90eps)
+          prTemp = 1. _d 0
+          IF ( RiNumber .GE. 0.2 _d 0 ) prTemp = 5. _d 0 * RiNumber
+          TKEPrandtlNumber(i,j,k) = MIN(10. _d 0,prTemp)
+         ENDDO
+        ENDDO
+#ifdef ALLOW_GGL90_IDEMIX
+       ENDIF
+#endif /* ALLOW_GGL90_IDEMIX */
+
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+C        diffusivity
+         KappaH = KappaM(i,j)/TKEPrandtlNumber(i,j,k)
+         KappaE(i,j,k) = GGL90alpha * KappaM(i,j) * maskC(i,j,k,bi,bj)
+
+C     dissipation term
+         TKEdissipation = explDissFac*GGL90ceps
+     &        *SQRTTKE(i,j,k)*rMixingLength(i,j,k)
+     &        *GGL90TKE(i,j,k,bi,bj)
+
+CIGF use explDissFacSI under shelfice
+#ifdef ALLOW_SHELFICE
+         IF (kTopC(i,j,bi,bj) .GT. 0) THEN
+          TKEdissipation = explDissFacSI*GGL90ceps
+     &        *SQRTTKE(i,j,k)*rMixingLength(i,j,k)
+     &        *GGL90TKE(i,j,k,bi,bj)
+         ENDIF
+#endif
+
+C     partial update with sum of explicit contributions
+#ifdef ALLOW_SHELFICE
+        IF ((kTopC(i,j,bi,bj) .GT. 0) .AND.
+     &      (maskC(i,j,k, bi,bj) .GT. 0)) THEN
+         IF ( debugLevel.GE.debLevE )
+     &   print  '(A,4i4,1(1x,1P3E15.6))',
+     &   'GGLT i,j,k,kTopC GGL90TKE PRE  ',i,j,k, 
+     &    kTopC(i,j,bi,bj),
+     &    GGL90TKE(i,j,k,bi,bj)
+        ENDIF
+#endif
+ 
+         GGL90TKE(i,j,k,bi,bj) = GGL90TKE(i,j,k,bi,bj)
+     &        + deltaTggl90*(
+     &        + KappaM(i,j)*verticalShear(i,j)
+     &        - KappaH*Nsquare(i,j,k)
+     &        - TKEdissipation
+     &        )
+
+#ifdef ALLOW_SHELFICE
+        IF ( debugLevel.GE.debLevE ) THEN
+         IF ((kTopC(i,j,bi,bj) .GT. 0) .AND.
+     &       (maskC(i,j,k, bi,bj) .GT. 0)) THEN
+         print  '(A,4i4,1(1x,1P3E15.6))',
+     &   'GGLT i,j,k,kTopC GGL90TKE POST ', i,j,k, 
+     &    kTopC(i,j,bi,bj),
+     &    GGL90TKE(i,j,k,bi,bj)
+
+         print  '(A,4i4,3(1x,1P3E10.1))',
+     &    'GGLT i,j,k,kTopC A+B ', i,j,k, kTopC(i,j,bi,bj),
+     &     KappaM(i,j)*verticalShear(i,j),
+     &     - KappaH*Nsquare(i,j,k)
+
+         print  '(A,4i4,3(1x,1P3E10.1))',
+     &    'GGLT i,j,k,kTopC +C ', i,j,k, kTopC(i,j,bi,bj),
+     &     - TKEdissipation
+         ENDIF
+        ENDIF
+#endif
+
+        ENDDO
+       ENDDO
+
+#ifdef ALLOW_GGL90_IDEMIX
+       IF ( useIDEMIX ) THEN
+C     add IDEMIX contribution to the turbulent kinetic energy
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          GGL90TKE(i,j,k,bi,bj) = GGL90TKE(i,j,k,bi,bj)
+     &         + deltaTggl90*(
+     &         + IDEMIX_tau_d(i,j,k,bi,bj)*IDEMIX_E(i,j,k,bi,bj)**2
+     &         )
+         ENDDO
+        ENDDO
+       ENDIF
+#endif /* ALLOW_GGL90_IDEMIX */
+
+#ifdef ALLOW_GGL90_HORIZDIFF
+       IF ( GGL90diffTKEh .GT. 0. _d 0 ) THEN
+C--    Add horiz. diffusion tendency
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          GGL90TKE(i,j,k,bi,bj) = GGL90TKE(i,j,k,bi,bj)
+     &                          + gTKE(i,j)*deltaTggl90
+         ENDDO
+        ENDDO
+       ENDIF
+#endif /* ALLOW_GGL90_HORIZDIFF */
+
+C--   end of k loop
+      ENDDO
+
+C     ============================================
+C     Implicit time step to update TKE for k=1,Nr;
+C     TKE(Nr+1)=0 by default
+C     ============================================
+C     set up matrix
+C--   Lower diagonal
+      DO j=jMin,jMax
+       DO i=iMin,iMax
+         a3d(i,j,1) = 0. _d 0
+       ENDDO
+      ENDDO
+      DO k=2,Nr
+       km1=MAX(2,k-1)
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+C-    We keep recip_hFacC in the diffusive flux calculation,
+C-    but no hFacC in TKE volume control
+C-    No need for maskC(k-1) with recip_hFacC(k-1)
+         a3d(i,j,k) = -deltaTggl90
+     &        *recip_drF(k-1)*recip_hFacC(i,j,k-1,bi,bj)
+     &        *.5 _d 0*(KappaE(i,j, k )+KappaE(i,j,km1))
+     &        *recip_drC(k)*maskC(i,j,k,bi,bj)
+        ENDDO
+       ENDDO
+      ENDDO
+C--   Upper diagonal
+      DO j=jMin,jMax
+       DO i=iMin,iMax
+         c3d(i,j,1)  = 0. _d 0
+       ENDDO
+      ENDDO
+      DO k=2,Nr
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+         kp1=MAX(1,MIN(klowC(i,j,bi,bj),k+1))
+C-    We keep recip_hFacC in the diffusive flux calculation,
+C-    but no hFacC in TKE volume control
+C-    No need for maskC(k) with recip_hFacC(k)
+         c3d(i,j,k) = -deltaTggl90
+     &        *recip_drF( k ) * recip_hFacC(i,j,k,bi,bj)
+     &        *.5 _d 0*(KappaE(i,j,k)+KappaE(i,j,kp1))
+     &        *recip_drC(k)*maskC(i,j,k-1,bi,bj)
+        ENDDO
+       ENDDO
+      ENDDO
+
+#ifdef ALLOW_GGL90_IDEMIX
+      IF ( useIDEMIX ) THEN
+       DO k=2,Nr
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+          a3d(i,j,k) = a3d(i,j,k)*recip_hFacI(i,j,k)
+          c3d(i,j,k) = c3d(i,j,k)*recip_hFacI(i,j,k)
+         ENDDO
+        ENDDO
+       ENDDO
+      ENDIF
+#endif /* ALLOW_GGL90_IDEMIX */
+
+      IF (.NOT.GGL90_dirichlet) THEN
+C      Neumann bottom boundary condition for TKE: no flux from bottom
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+         kBottom   = MAX(kLowC(i,j,bi,bj),1)
+         c3d(i,j,kBottom) = 0. _d 0
+        ENDDO
+       ENDDO
+      ENDIF
+
+C--   Center diagonal
+      DO k=1,Nr
+       km1 = MAX(k-1,1)
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+         b3d(i,j,k) = 1. _d 0 - c3d(i,j,k) - a3d(i,j,k)
+     &        + implDissFac*deltaTggl90*GGL90ceps*SQRTTKE(i,j,k)
+     &        * rMixingLength(i,j,k)
+     &        * maskC(i,j,k,bi,bj)*maskC(i,j,km1,bi,bj)
+CIGF use implDissFacSI under shelf ice
+#ifdef ALLOW_SHELFICE
+         IF (kTopC(i,j,bi,bj) .GT. 0) THEN
+          b3d(i,j,k) = 1. _d 0 - c3d(i,j,k) - a3d(i,j,k)
+     &        + implDissFacSI*deltaTggl90*GGL90ceps*SQRTTKE(i,j,k)
+     &        * rMixingLength(i,j,k)
+     &        * maskC(i,j,k,bi,bj)*maskC(i,j,km1,bi,bj)
+         ENDIF
+#endif
+
+        ENDDO
+       ENDDO
+      ENDDO
+C     end set up matrix
+
+C     Apply boundary condition
+      kp1 = MIN(Nr,kSurf+1)
+      DO j=jMin,jMax
+       DO i=iMin,iMax
+C     estimate friction velocity uStar from surface forcing
+        uStarSquare = SQRT(
+     &    ( .5 _d 0*( surfaceForcingU(i,  j,  bi,bj)
+     &              + surfaceForcingU(i+1,j,  bi,bj) ) )**2
+     &  + ( .5 _d 0*( surfaceForcingV(i,  j,  bi,bj)
+     &              + surfaceForcingV(i,  j+1,bi,bj) ) )**2
+     &                     )
+
+
+C     Dirichlet surface boundary condition for TKE
+
+CIGF SET KSURF TO KTOPC WHERE KTOPC IS NONZERO
+CIGF and also set uStarSquare to zero (no influence of surface forcing)
+#ifdef ALLOW_SHELFICE
+        IF (kTopC(i,j,bi,bj) .GT. 0) THEN
+          kSurf = kTopC(i,j,bi,bj)
+          uStarSquare = 0.0 _d 0
+        ELSE
+          kSurf = 1
+        ENDIF
+        kp1 = MIN(Nr,kSurf+1)
+#endif      
+
+        GGL90TKE(i,j,kSurf,bi,bj) = maskC(i,j,kSurf,bi,bj)
+     &           *MAX(GGL90TKEsurfMin,GGL90m2*uStarSquare)
+        GGL90TKE(i,j,kp1,bi,bj) = GGL90TKE(i,j,kp1,bi,bj)
+     &               - a3d(i,j,kp1)*GGL90TKE(i,j,kSurf,bi,bj)
+        a3d(i,j,kp1) = 0. _d 0
+       ENDDO
+      ENDDO
+
+      IF (GGL90_dirichlet) THEN
+C      Dirichlet bottom boundary condition for TKE = GGL90TKEbottom
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+         kBottom   = MAX(kLowC(i,j,bi,bj),1)
+         GGL90TKE(i,j,kBottom,bi,bj) = GGL90TKE(i,j,kBottom,bi,bj)
+     &                              - GGL90TKEbottom*c3d(i,j,kBottom)
+         c3d(i,j,kBottom) = 0. _d 0
+        ENDDO
+       ENDDO
+      ENDIF
+
+C     solve tri-diagonal system
+      errCode = -1
+      CALL SOLVE_TRIDIAGONAL( iMin,iMax, jMin,jMax,
+     I                        a3d, b3d, c3d,
+     U                        GGL90TKE(1-OLx,1-OLy,1,bi,bj),
+     O                        errCode,
+     I                        bi, bj, myThid )
+
+      DO k=1,Nr
+       DO j=jMin,jMax
+        DO i=iMin,iMax
+C     impose minimum TKE to avoid numerical undershoots below zero
+         GGL90TKE(i,j,k,bi,bj) = maskC(i,j,k,bi,bj)
+     &                  *MAX( GGL90TKE(i,j,k,bi,bj), GGL90TKEmin )
+        ENDDO
+       ENDDO
+      ENDDO
+
+C     end of time step
+C     ===============================
+
+      DO k=2,Nr
+       DO j=1,sNy
+        DO i=1,sNx
+#ifdef ALLOW_GGL90_SMOOTH
+         tmpVisc = (
+     &     p4 *    GGL90visctmp(i  ,j  ,k)*mskCor(i  ,j  ,bi,bj)
+     &    +p8 *( ( GGL90visctmp(i-1,j  ,k)*mskCor(i-1,j  ,bi,bj)
+     &           + GGL90visctmp(i+1,j  ,k)*mskCor(i+1,j  ,bi,bj) )
+     &         + ( GGL90visctmp(i  ,j-1,k)*mskCor(i  ,j-1,bi,bj)
+     &           + GGL90visctmp(i  ,j+1,k)*mskCor(i  ,j+1,bi,bj) ) )
+     &    +p16*( ( GGL90visctmp(i+1,j+1,k)*mskCor(i+1,j+1,bi,bj)
+     &           + GGL90visctmp(i-1,j-1,k)*mskCor(i-1,j-1,bi,bj) )
+     &         + ( GGL90visctmp(i+1,j-1,k)*mskCor(i+1,j-1,bi,bj)
+     &           + GGL90visctmp(i-1,j+1,k)*mskCor(i-1,j+1,bi,bj) ) )
+     &             )/(
+     &     p4
+     &    +p8 *( (  maskC(i-1,j  ,k,bi,bj)*mskCor(i-1,j  ,bi,bj)
+     &           +  maskC(i+1,j  ,k,bi,bj)*mskCor(i+1,j  ,bi,bj) )
+     &         + (  maskC(i  ,j-1,k,bi,bj)*mskCor(i  ,j-1,bi,bj)
+     &           +  maskC(i  ,j+1,k,bi,bj)*mskCor(i  ,j+1,bi,bj) ) )
+     &    +p16*( (  maskC(i+1,j+1,k,bi,bj)* mskCor(i+1,j+1,bi,bj)
+     &           +  maskC(i-1,j-1,k,bi,bj)*mskCor(i-1,j-1,bi,bj) )
+     &         + (  maskC(i+1,j-1,k,bi,bj)*mskCor(i+1,j-1,bi,bj)
+     &           +  maskC(i-1,j+1,k,bi,bj)*mskCor(i-1,j+1,bi,bj) ) )
+     &               )*maskC(i,j,k,bi,bj)*mskCor(i,j,bi,bj)
+#else
+         tmpVisc = GGL90visctmp(i,j,k)
+#endif
+         tmpVisc = MIN(tmpVisc/TKEPrandtlNumber(i,j,k),GGL90diffMax)
+         GGL90diffKr(i,j,k,bi,bj)= MAX( tmpVisc , diffKrNrS(k) )
+        ENDDO
+       ENDDO
+      ENDDO
+
+      DO k=2,Nr
+       DO j=1,sNy
+        DO i=1,sNx+1
+#ifdef ALLOW_GGL90_SMOOTH
+         tmpVisc = (
+     &     p4 *(   GGL90visctmp(i-1,j  ,k)*mskCor(i-1,j  ,bi,bj)
+     &           + GGL90visctmp(i  ,j  ,k)*mskCor(i  ,j  ,bi,bj) )
+     &    +p8 *( ( GGL90visctmp(i-1,j-1,k)*mskCor(i-1,j-1,bi,bj)
+     &           + GGL90visctmp(i  ,j-1,k)*mskCor(i  ,j-1,bi,bj) )
+     &         + ( GGL90visctmp(i-1,j+1,k)*mskCor(i-1,j+1,bi,bj)
+     &           + GGL90visctmp(i  ,j+1,k)*mskCor(i  ,j+1,bi,bj) ) )
+     &             )/(
+     &     p4 * 2. _d 0
+     &    +p8 *( (  maskC(i-1,j-1,k,bi,bj)*mskCor(i-1,j-1,bi,bj)
+     &           +  maskC(i  ,j-1,k,bi,bj)*mskCor(i  ,j-1,bi,bj) )
+     &         + (  maskC(i-1,j+1,k,bi,bj)*mskCor(i-1,j+1,bi,bj)
+     &           +  maskC(i  ,j+1,k,bi,bj)*mskCor(i  ,j+1,bi,bj) ) )
+     &               )*maskC(i-1,j,k,bi,bj)*mskCor(i-1,j,bi,bj)
+     &                *maskC(i  ,j,k,bi,bj)*mskCor(i  ,j,bi,bj)
+#else
+         tmpVisc = _maskW(i,j,k,bi,bj) * halfRL
+     &          *( GGL90visctmp(i-1,j,k)
+     &           + GGL90visctmp(i,j,k) )
+#endif
+         tmpVisc = MIN( tmpVisc , GGL90viscMax )
+         GGL90viscArU(i,j,k,bi,bj) = MAX( tmpVisc, viscArNr(k) )
+        ENDDO
+       ENDDO
+      ENDDO
+
+      DO k=2,Nr
+       DO j=1,sNy+1
+        DO i=1,sNx
+#ifdef ALLOW_GGL90_SMOOTH
+         tmpVisc = (
+     &     p4 *(   GGL90visctmp(i  ,j-1,k)*mskCor(i  ,j-1,bi,bj)
+     &           + GGL90visctmp(i  ,j  ,k)*mskCor(i  ,j  ,bi,bj) )
+     &    +p8 *( ( GGL90visctmp(i-1,j-1,k)*mskCor(i-1,j-1,bi,bj)
+     &           + GGL90visctmp(i-1,j  ,k)*mskCor(i-1,j  ,bi,bj) )
+     &         + ( GGL90visctmp(i+1,j-1,k)*mskCor(i+1,j-1,bi,bj)
+     &           + GGL90visctmp(i+1,j  ,k)*mskCor(i+1,j  ,bi,bj) ) )
+     &             )/(
+     &     p4 * 2. _d 0
+     &    +p8 *( (  maskC(i-1,j-1,k,bi,bj)*mskCor(i-1,j-1,bi,bj)
+     &           +  maskC(i-1,j  ,k,bi,bj)*mskCor(i-1,j  ,bi,bj) )
+     &         + (  maskC(i+1,j-1,k,bi,bj)*mskCor(i+1,j-1,bi,bj)
+     &           +  maskC(i+1,j  ,k,bi,bj)*mskCor(i+1,j  ,bi,bj) ) )
+     &               )*maskC(i,j-1,k,bi,bj)*mskCor(i,j-1,bi,bj)
+     &                *maskC(i,j  ,k,bi,bj)*mskCor(i,j  ,bi,bj)
+#else
+         tmpVisc = _maskS(i,j,k,bi,bj) * halfRL
+     &          *( GGL90visctmp(i,j-1,k)
+     &           + GGL90visctmp(i,j,k) )
+#endif
+         tmpVisc = MIN( tmpVisc , GGL90viscMax )
+         GGL90viscArV(i,j,k,bi,bj) = MAX( tmpVisc, viscArNr(k) )
+        ENDDO
+       ENDDO
+      ENDDO
+
+#ifdef ALLOW_DIAGNOSTICS
+      IF ( useDiagnostics ) THEN
+        CALL DIAGNOSTICS_FILL( GGL90TKE   ,'GGL90TKE',
+     &                         0,Nr, 1, bi, bj, myThid )
+        CALL DIAGNOSTICS_FILL( GGL90viscArU,'GGL90ArU',
+     &                         0,Nr, 1, bi, bj, myThid )
+        CALL DIAGNOSTICS_FILL( GGL90viscArV,'GGL90ArV',
+     &                         0,Nr, 1, bi, bj, myThid )
+        CALL DIAGNOSTICS_FILL( GGL90diffKr,'GGL90Kr ',
+     &                         0,Nr, 1, bi, bj, myThid )
+        CALL DIAGNOSTICS_FILL( TKEPrandtlNumber ,'GGL90Prl',
+     &                         0,Nr, 2, bi, bj, myThid )
+        CALL DIAGNOSTICS_FILL( GGL90mixingLength,'GGL90Lmx',
+     &                         0,Nr, 2, bi, bj, myThid )
+
+        kp1 = MIN(Nr,kSurf+1)
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+C     diagnose surface flux of TKE
+          surf_flx_tke(i,j) =(GGL90TKE(i,j,kSurf,bi,bj)-
+     &                        GGL90TKE(i,j,kp1,bi,bj))
+     &        *recip_drF(kSurf)*recip_hFacC(i,j,kSurf,bi,bj)
+     &        *KappaE(i,j,kp1)
+         ENDDO
+        ENDDO
+        CALL DIAGNOSTICS_FILL( surf_flx_tke,'GGL90flx',
+     &                         0, 1, 2, bi, bj, myThid )
+
+        k=kSurf
+        DO j=jMin,jMax
+         DO i=iMin,iMax
+C     diagnose work done by the wind
+          surf_flx_tke(i,j) =
+     &      halfRL*( surfaceForcingU(i,  j,bi,bj)*uVel(i  ,j,k,bi,bj)
+     &              +surfaceForcingU(i+1,j,bi,bj)*uVel(i+1,j,k,bi,bj))
+     &    + halfRL*( surfaceForcingV(i,j,  bi,bj)*vVel(i,j  ,k,bi,bj)
+     &              +surfaceForcingV(i,j+1,bi,bj)*vVel(i,j+1,k,bi,bj))
+         ENDDO
+        ENDDO
+        CALL DIAGNOSTICS_FILL( surf_flx_tke,'GGL90tau',
+     &                         0, 1, 2, bi, bj, myThid )
+
+      ENDIF
+#endif /* ALLOW_DIAGNOSTICS */
+
+#endif /* ALLOW_GGL90 */
+
+      RETURN
+      END

--- a/devel/V4r5_devel/code/gmredi_calc_tensor.F
+++ b/devel/V4r5_devel/code/gmredi_calc_tensor.F
@@ -1,0 +1,1225 @@
+#include "GMREDI_OPTIONS.h"
+#ifdef ALLOW_AUTODIFF
+# include "AUTODIFF_OPTIONS.h"
+#endif
+#ifdef ALLOW_CTRL
+# include "CTRL_OPTIONS.h"
+#endif
+#ifdef ALLOW_KPP
+# include "KPP_OPTIONS.h"
+#endif
+
+CBOP
+C     !ROUTINE: GMREDI_CALC_TENSOR
+C     !INTERFACE:
+      SUBROUTINE GMREDI_CALC_TENSOR(
+     I             iMin, iMax, jMin, jMax,
+     I             sigmaX, sigmaY, sigmaR,
+     I             bi, bj, myTime, myIter, myThid )
+
+C     !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SUBROUTINE GMREDI_CALC_TENSOR
+C     | o Calculate tensor elements for GM/Redi tensor.
+C     *==========================================================*
+C     *==========================================================*
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == Global variables ==
+#include "SIZE.h"
+#include "GRID.h"
+#include "DYNVARS.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "GMREDI.h"
+#include "GMREDI_TAVE.h"
+#ifdef ALLOW_CTRL
+# include "CTRL_FIELDS.h"
+#endif
+#ifdef ALLOW_KPP
+# include "KPP.h"
+#endif
+
+#ifdef ALLOW_SHELFICE
+#include "SHELFICE.h"
+#endif
+
+#ifdef ALLOW_AUTODIFF_TAMC
+#include "tamc.h"
+#include "tamc_keys.h"
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     == Routine arguments ==
+C     bi, bj    :: tile indices
+C     myTime    :: Current time in simulation
+C     myIter    :: Current iteration number in simulation
+C     myThid    :: My Thread Id. number
+C
+      INTEGER iMin,iMax,jMin,jMax
+      _RL sigmaX(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL sigmaY(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL sigmaR(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      INTEGER bi, bj
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
+CEOP
+
+#ifdef ALLOW_GMREDI
+
+C     !LOCAL VARIABLES:
+C     == Local variables ==
+      INTEGER i,j,k
+      _RL SlopeX(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL SlopeY(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL dSigmaDx(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL dSigmaDy(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL dSigmaDr(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL SlopeSqr(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL taperFct(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL ldd97_LrhoC(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL ldd97_LrhoW(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL ldd97_LrhoS(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL Cspd, LrhoInf, LrhoSup, fCoriLoc
+      _RL Kgm_tmp, isopycK, bolus_K
+
+      INTEGER kLow_W (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      INTEGER kLow_S (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL locMixLayer(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL baseSlope  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL hTransLay  (1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      _RL recipLambda(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+      INTEGER  km1
+#if ( defined (GM_NON_UNITY_DIAGONAL) || defined (GM_EXTRA_DIAGONAL) )
+      INTEGER kp1
+      _RL maskp1
+#endif
+
+#ifdef GM_VISBECK_VARIABLE_K
+#ifdef OLD_VISBECK_CALC
+      _RL Ssq(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+#else
+      _RL dSigmaH, dSigmaR
+      _RL Sloc, M2loc
+#endif
+      _RL recipMaxSlope
+      _RL deltaH, integrDepth
+      _RL N2loc, SNloc
+#endif /* GM_VISBECK_VARIABLE_K */
+
+#ifdef ALLOW_DIAGNOSTICS
+      LOGICAL  doDiagRediFlx
+      LOGICAL  DIAGNOSTICS_IS_ON
+      EXTERNAL DIAGNOSTICS_IS_ON
+#if ( defined (GM_NON_UNITY_DIAGONAL) || defined (GM_EXTRA_DIAGONAL) )
+      _RL dTdz
+      _RL tmp1k(1-OLx:sNx+OLx,1-OLy:sNy+OLy)
+#endif
+#endif /* ALLOW_DIAGNOSTICS */
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+#ifdef ALLOW_AUTODIFF_TAMC
+          act1 = bi - myBxLo(myThid)
+          max1 = myBxHi(myThid) - myBxLo(myThid) + 1
+          act2 = bj - myByLo(myThid)
+          max2 = myByHi(myThid) - myByLo(myThid) + 1
+          act3 = myThid - 1
+          max3 = nTx*nTy
+          act4 = ikey_dynamics - 1
+          igmkey = (act1 + 1) + act2*max1
+     &                      + act3*max1*max2
+     &                      + act4*max1*max2*max3
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+#ifdef ALLOW_DIAGNOSTICS
+      doDiagRediFlx = .FALSE.
+      IF ( useDiagnostics ) THEN
+        doDiagRediFlx = DIAGNOSTICS_IS_ON('GM_KuzTz', myThid )
+        doDiagRediFlx = doDiagRediFlx .OR.
+     &                  DIAGNOSTICS_IS_ON('GM_KvzTz', myThid )
+      ENDIF
+#endif
+
+#ifdef GM_VISBECK_VARIABLE_K
+      recipMaxSlope = 0. _d 0
+      IF ( GM_Visbeck_maxSlope.GT.0. _d 0 ) THEN
+        recipMaxSlope = 1. _d 0 / GM_Visbeck_maxSlope
+      ENDIF
+      DO j=1-OLy,sNy+OLy
+       DO i=1-OLx,sNx+OLx
+        VisbeckK(i,j,bi,bj) = 0. _d 0
+       ENDDO
+      ENDDO
+#endif
+
+C--   set ldd97_Lrho (for tapering scheme ldd97):
+      IF ( GM_taper_scheme.EQ.'ldd97' .OR.
+     &     GM_taper_scheme.EQ.'fm07' ) THEN
+       Cspd = 2. _d 0
+       LrhoInf = 15. _d 3
+       LrhoSup = 100. _d 3
+C-     Tracer point location (center):
+       DO j=1-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+         IF (fCori(i,j,bi,bj).NE.0.) THEN
+           ldd97_LrhoC(i,j) = Cspd/ABS(fCori(i,j,bi,bj))
+         ELSE
+           ldd97_LrhoC(i,j) = LrhoSup
+         ENDIF
+         ldd97_LrhoC(i,j) = MAX(LrhoInf,MIN(ldd97_LrhoC(i,j),LrhoSup))
+        ENDDO
+       ENDDO
+C-     U point location (West):
+       DO j=1-OLy,sNy+OLy
+        kLow_W(1-OLx,j) = 0
+        ldd97_LrhoW(1-OLx,j) = LrhoSup
+        DO i=1-OLx+1,sNx+OLx
+         kLow_W(i,j) = MIN(kLowC(i-1,j,bi,bj),kLowC(i,j,bi,bj))
+         fCoriLoc = op5*(fCori(i-1,j,bi,bj)+fCori(i,j,bi,bj))
+         IF (fCoriLoc.NE.0.) THEN
+           ldd97_LrhoW(i,j) = Cspd/ABS(fCoriLoc)
+         ELSE
+           ldd97_LrhoW(i,j) = LrhoSup
+         ENDIF
+         ldd97_LrhoW(i,j) = MAX(LrhoInf,MIN(ldd97_LrhoW(i,j),LrhoSup))
+        ENDDO
+       ENDDO
+C-     V point location (South):
+       DO i=1-OLx+1,sNx+OLx
+         kLow_S(i,1-OLy) = 0
+         ldd97_LrhoS(i,1-OLy) = LrhoSup
+       ENDDO
+       DO j=1-OLy+1,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+         kLow_S(i,j) = MIN(kLowC(i,j-1,bi,bj),kLowC(i,j,bi,bj))
+         fCoriLoc = op5*(fCori(i,j-1,bi,bj)+fCori(i,j,bi,bj))
+         IF (fCoriLoc.NE.0.) THEN
+           ldd97_LrhoS(i,j) = Cspd/ABS(fCoriLoc)
+         ELSE
+           ldd97_LrhoS(i,j) = LrhoSup
+         ENDIF
+         ldd97_LrhoS(i,j) = MAX(LrhoInf,MIN(ldd97_LrhoS(i,j),LrhoSup))
+        ENDDO
+       ENDDO
+      ELSE
+C-    Just initialize to zero (not use anyway)
+       DO j=1-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+          ldd97_LrhoC(i,j) = 0. _d 0
+          ldd97_LrhoW(i,j) = 0. _d 0
+          ldd97_LrhoS(i,j) = 0. _d 0
+        ENDDO
+       ENDDO
+      ENDIF
+
+#ifdef GM_BOLUS_ADVEC
+      DO k=1,Nr
+       DO j=1-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+         GM_PsiX(i,j,k,bi,bj)  = 0. _d 0
+         GM_PsiY(i,j,k,bi,bj)  = 0. _d 0
+        ENDDO
+       ENDDO
+      ENDDO
+#endif /* GM_BOLUS_ADVEC */
+#ifdef ALLOW_AUTODIFF
+      DO k=1,Nr
+       DO j=1-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+         Kwx(i,j,k,bi,bj)  = 0. _d 0
+         Kwy(i,j,k,bi,bj)  = 0. _d 0
+         Kwz(i,j,k,bi,bj)  = 0. _d 0
+# ifdef GM_NON_UNITY_DIAGONAL
+         Kux(i,j,k,bi,bj)  = 0. _d 0
+         Kvy(i,j,k,bi,bj)  = 0. _d 0
+# endif
+# ifdef GM_EXTRA_DIAGONAL
+         Kuz(i,j,k,bi,bj)  = 0. _d 0
+         Kvz(i,j,k,bi,bj)  = 0. _d 0
+# endif
+        ENDDO
+       ENDDO
+      ENDDO
+#endif /* ALLOW_AUTODIFF */
+
+C--   Initialise Mixed Layer related array:
+      DO j=1-OLy,sNy+OLy
+       DO i=1-OLx,sNx+OLx
+         hTransLay(i,j) = R_low(i,j,bi,bj)
+         baseSlope(i,j) =  0. _d 0
+         recipLambda(i,j) = 0. _d 0
+         locMixLayer(i,j) = 0. _d 0
+       ENDDO
+      ENDDO
+#ifdef ALLOW_KPP
+      IF ( useKPP ) THEN
+       DO j=1-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+         locMixLayer(i,j) = KPPhbl(i,j,bi,bj)
+        ENDDO
+       ENDDO
+      ELSE
+#else
+      IF ( .TRUE. ) THEN
+#endif
+       DO j=1-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+         locMixLayer(i,j) = hMixLayer(i,j,bi,bj)
+        ENDDO
+       ENDDO
+      ENDIF
+
+#ifdef GM_K3D
+      IF (GM_useK3D) THEN
+C     Calculate the 3D diffusivity as per Bates et al. (2013)
+        CALL TIMER_START('GMREDI_K3D      [GMREDI_CALC_TENSOR]',
+     &                    myThid)
+
+        CALL GMREDI_K3D(
+     I       iMin, iMax, jMin, jMax,
+     I       sigmaX, sigmaY, sigmaR,
+     I       bi, bj, myTime, myThid)
+
+        CALL TIMER_STOP('GMREDI_K3D      [GMREDI_CALC_TENSOR]',
+     &                  myThid)
+      ENDIF
+#endif
+
+#ifdef ALLOW_GM_LEITH_QG
+C   Use Leith QG viscosity in GMRedi scheme
+      IF (GM_useLeithQG) THEN
+        DO k=1,Nr
+          DO j=1-OLy,sNy+OLy
+            DO i=1-OLx,sNx+OLx
+              GM_LeithQG_K(i,j,k,bi,bj) = 0. _d 0
+            ENDDO
+          ENDDO
+        ENDDO
+        IF ( viscC2LeithQG.NE.0. ) THEN
+          CALL GMREDI_CALC_QGLEITH(
+     O                GM_LeithQG_K(1-OLx,1-OLy,1,bi,bj),
+     I                bi, bj, myTime, myIter, myThid )
+        ENDIF
+      ENDIF
+#endif /* ALLOW_GM_LEITH_QG */
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C-- 1rst loop on k : compute Tensor Coeff. at W points.
+
+      DO k=Nr,2,-1
+
+#ifdef ALLOW_AUTODIFF
+       DO j=1-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+         SlopeX(i,j)       = 0. _d 0
+         SlopeY(i,j)       = 0. _d 0
+         dSigmaDx(i,j)     = 0. _d 0
+         dSigmaDy(i,j)     = 0. _d 0
+         dSigmaDr(i,j)     = 0. _d 0
+         SlopeSqr(i,j)     = 0. _d 0
+         taperFct(i,j)     = 0. _d 0
+        ENDDO
+       ENDDO
+#endif /* ALLOW_AUTODIFF */
+
+       DO j=1-OLy+1,sNy+OLy-1
+        DO i=1-OLx+1,sNx+OLx-1
+C      Gradient of Sigma at rVel points
+         dSigmaDx(i,j)=op25*( sigmaX(i+1,j,k-1)+sigmaX(i,j,k-1)
+     &                       +sigmaX(i+1,j, k )+sigmaX(i,j, k )
+     &                      )*maskC(i,j,k,bi,bj)*maskC(i,j,k-1,bi,bj)
+         dSigmaDy(i,j)=op25*( sigmaY(i,j+1,k-1)+sigmaY(i,j,k-1)
+     &                       +sigmaY(i,j+1, k )+sigmaY(i,j, k )
+     &                      )*maskC(i,j,k,bi,bj)*maskC(i,j,k-1,bi,bj)
+c        dSigmaDr(i,j)=sigmaR(i,j,k)
+        ENDDO
+       ENDDO
+
+#ifdef GM_VISBECK_VARIABLE_K
+#ifndef OLD_VISBECK_CALC
+       IF ( GM_Visbeck_alpha.GT.0. .AND.
+     &      -rC(k-1).LT.GM_Visbeck_depth ) THEN
+
+        DO j=1-OLy,sNy+OLy
+         DO i=1-OLx,sNx+OLx
+          dSigmaDr(i,j) = MIN( sigmaR(i,j,k), 0. _d 0 )
+         ENDDO
+        ENDDO
+
+C--     Depth average of f/sqrt(Ri) = M^2/N^2 * N
+C       M^2 and N^2 are horizontal & vertical gradient of buoyancy.
+
+C       Calculate terms for mean Richardson number which is used
+C       in the "variable K" parameterisaton:
+C       compute depth average from surface down to the bottom or
+C       GM_Visbeck_depth, whatever is the shallower.
+
+        DO j=1-OLy+1,sNy+OLy-1
+         DO i=1-OLx+1,sNx+OLx-1
+          IF ( maskC(i,j,k,bi,bj).NE.0. ) THEN
+           integrDepth = -rC( kLowC(i,j,bi,bj) )
+C-      in 2 steps to avoid mix of RS & RL type in min fct. arguments
+           integrDepth = MIN( integrDepth, GM_Visbeck_depth )
+C-      to recover "old-visbeck" form with Visbeck_minDepth = Visbeck_depth
+           integrDepth = MAX( integrDepth, GM_Visbeck_minDepth )
+C       Distance between level center above and the integration depth
+           deltaH = integrDepth + rC(k-1)
+C       If negative then we are below the integration level
+C       (cannot be the case with 2 conditions on maskC & -rC(k-1))
+C       If positive we limit this to the distance from center above
+           deltaH = MIN( deltaH, drC(k) )
+C       Now we convert deltaH to a non-dimensional fraction
+           deltaH = deltaH/( integrDepth+rC(1) )
+
+C--      compute: ( M^2 * S )^1/2   (= S*N since S=M^2/N^2 )
+C        a 5 points average gives a more "homogeneous" formulation
+C        (same stencil and same weights as for dSigmaH calculation)
+           dSigmaR = ( dSigmaDr(i,j)*4. _d 0
+     &               + dSigmaDr(i-1,j)
+     &               + dSigmaDr(i+1,j)
+     &               + dSigmaDr(i,j-1)
+     &               + dSigmaDr(i,j+1)
+     &               )/( 4. _d 0
+     &                 + maskC(i-1,j,k,bi,bj)
+     &                 + maskC(i+1,j,k,bi,bj)
+     &                 + maskC(i,j-1,k,bi,bj)
+     &                 + maskC(i,j+1,k,bi,bj)
+     &                 )
+           dSigmaH = dSigmaDx(i,j)*dSigmaDx(i,j)
+     &             + dSigmaDy(i,j)*dSigmaDy(i,j)
+           IF ( dSigmaH .GT. 0. _d 0 ) THEN
+             dSigmaH = SQRT( dSigmaH )
+C-       compute slope, limited by GM_Visbeck_maxSlope:
+             IF ( -dSigmaR.GT.dSigmaH*recipMaxSlope ) THEN
+              Sloc = dSigmaH / ( -dSigmaR )
+             ELSE
+              Sloc = GM_Visbeck_maxSlope
+             ENDIF
+             M2loc = gravity*recip_rhoConst*dSigmaH
+c            SNloc = SQRT( Sloc*M2loc )
+             N2loc = -gravity*recip_rhoConst*dSigmaR
+c            N2loc = -gravity*recip_rhoConst*dSigmaDr(i,j)
+             IF ( N2loc.GT.0. _d 0 ) THEN
+               SNloc = Sloc*SQRT(N2loc)
+             ELSE
+               SNloc = 0. _d 0
+             ENDIF
+           ELSE
+             SNloc = 0. _d 0
+           ENDIF
+           VisbeckK(i,j,bi,bj) = VisbeckK(i,j,bi,bj)
+     &       +deltaH*GM_Visbeck_alpha
+     &              *GM_Visbeck_length*GM_Visbeck_length*SNloc
+          ENDIF
+         ENDDO
+        ENDDO
+       ENDIF
+#endif /* ndef OLD_VISBECK_CALC */
+#endif /* GM_VISBECK_VARIABLE_K */
+       DO j=1-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+         dSigmaDr(i,j)=sigmaR(i,j,k)
+#ifdef ALLOW_SHELFICE
+        IF ( debugLevel.GE.debLevE ) THEN
+        IF ((kTopC(i,j,bi,bj) .GT. 0) .AND.
+     &      (k .LE. kTopC(i,j,bi,bj))) THEN
+
+             print '(A,4i4,3(1x,1P3E15.6))',
+     &              'GMCT i j k kT dSigma ', i,j,k,
+     &              kTopC(i,j,bi,bj),
+     &              dSigmaDr(i,j)
+              
+        ENDIF
+        ENDIF
+#endif 
+        ENDDO
+       ENDDO
+
+#ifdef ALLOW_AUTODIFF_TAMC
+       kkey = (igmkey-1)*Nr + k
+CADJ STORE dSigmaDx(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE dSigmaDy(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE dSigmaDr(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE baseSlope(:,:)      = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE hTransLay(:,:)      = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE recipLambda(:,:)    = comlev1_bibj_k, key=kkey, byte=isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+C     Calculate slopes for use in tensor, taper and/or clip
+CADJ INCOMPLETE taperFct
+       CALL GMREDI_SLOPE_LIMIT(
+     O             SlopeX, SlopeY,
+     O             SlopeSqr, taperFct,
+     U             hTransLay, baseSlope, recipLambda,
+     U             dSigmaDr,
+     I             dSigmaDx, dSigmaDy,
+     I             ldd97_LrhoC, locMixLayer, rF,
+     I             kLowC(1-OLx,1-OLy,bi,bj),
+     I             k, bi, bj, myTime, myIter, myThid )
+
+       DO j=1-OLy+1,sNy+OLy-1
+        DO i=1-OLx+1,sNx+OLx-1
+C      Mask Iso-neutral slopes
+         SlopeX(i,j)=SlopeX(i,j)*maskC(i,j,k,bi,bj)
+         SlopeY(i,j)=SlopeY(i,j)*maskC(i,j,k,bi,bj)
+         SlopeSqr(i,j)=SlopeSqr(i,j)*maskC(i,j,k,bi,bj)
+        ENDDO
+       ENDDO
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE SlopeX(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE SlopeY(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE SlopeSqr(:,:)     = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE dSigmaDr(:,:)     = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE taperFct(:,:)     = comlev1_bibj_k, key=kkey, byte=isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+C      Components of Redi/GM tensor
+       DO j=1-OLy+1,sNy+OLy-1
+        DO i=1-OLx+1,sNx+OLx-1
+          Kwx(i,j,k,bi,bj)= SlopeX(i,j)*taperFct(i,j)
+          Kwy(i,j,k,bi,bj)= SlopeY(i,j)*taperFct(i,j)
+          Kwz(i,j,k,bi,bj)= SlopeSqr(i,j)*taperFct(i,j)
+        ENDDO
+       ENDDO
+
+#ifdef GM_VISBECK_VARIABLE_K
+#ifdef OLD_VISBECK_CALC
+       DO j=1-OLy+1,sNy+OLy-1
+        DO i=1-OLx+1,sNx+OLx-1
+
+C- note (jmc) : moved here since only used in VISBECK_VARIABLE_K
+C           but do not know if *taperFct (or **2 ?) is necessary
+        Ssq(i,j)=SlopeSqr(i,j)*taperFct(i,j)
+
+C--     Depth average of M^2/N^2 * N
+
+C       Calculate terms for mean Richardson number
+C       which is used in the "variable K" parameterisaton.
+C       Distance between interface above layer and the integration depth
+        deltaH=abs(GM_Visbeck_depth)-abs(rF(k))
+C       If positive we limit this to the layer thickness
+        integrDepth = drF(k)
+        deltaH=min(deltaH,integrDepth)
+C       If negative then we are below the integration level
+        deltaH=max(deltaH, 0. _d 0)
+C       Now we convert deltaH to a non-dimensional fraction
+        deltaH=deltaH/GM_Visbeck_depth
+
+        IF ( Ssq(i,j).NE.0. .AND. dSigmaDr(i,j).NE.0. ) THEN
+         N2loc = -gravity*recip_rhoConst*dSigmaDr(i,j)
+         SNloc = SQRT(Ssq(i,j)*N2loc )
+         VisbeckK(i,j,bi,bj) = VisbeckK(i,j,bi,bj)
+     &       +deltaH*GM_Visbeck_alpha
+     &              *GM_Visbeck_length*GM_Visbeck_length*SNloc
+        ENDIF
+
+        ENDDO
+       ENDDO
+#endif /* OLD_VISBECK_CALC */
+#endif /* GM_VISBECK_VARIABLE_K */
+
+C-- end 1rst loop on vertical level index k
+      ENDDO
+
+#ifdef GM_VISBECK_VARIABLE_K
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE VisbeckK(:,:,bi,bj) = comlev1_bibj, key=igmkey, byte=isbyte
+#endif
+      IF ( GM_Visbeck_alpha.GT.0. ) THEN
+C-     Limit range that KapGM can take
+       DO j=1-OLy+1,sNy+OLy-1
+        DO i=1-OLx+1,sNx+OLx-1
+         VisbeckK(i,j,bi,bj)=
+     &       MIN( MAX( VisbeckK(i,j,bi,bj), GM_Visbeck_minVal_K ),
+     &            GM_Visbeck_maxVal_K )
+        ENDDO
+       ENDDO
+      ENDIF
+cph( NEW
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE VisbeckK(:,:,bi,bj) = comlev1_bibj, key=igmkey, byte=isbyte
+#endif
+cph)
+#endif /* GM_VISBECK_VARIABLE_K */
+
+C-    express the Tensor in term of Diffusivity (= m**2 / s )
+      DO k=1,Nr
+#ifdef ALLOW_AUTODIFF_TAMC
+       kkey = (igmkey-1)*Nr + k
+# if (defined (GM_NON_UNITY_DIAGONAL) || \
+      defined (GM_VISBECK_VARIABLE_K))
+CADJ STORE Kwx(:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE Kwy(:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE Kwz(:,:,k,bi,bj) = comlev1_bibj_k, key=kkey, byte=isbyte
+# endif
+#endif
+       km1 = MAX(k-1,1)
+       isopycK = GM_isopycK
+     &         *(GM_isoFac1d(km1)+GM_isoFac1d(k))*op5
+       bolus_K = GM_background_K
+     &         *(GM_bolFac1d(km1)+GM_bolFac1d(k))*op5
+       DO j=1-OLy+1,sNy+OLy-1
+        DO i=1-OLx+1,sNx+OLx-1
+#ifdef ALLOW_KAPREDI_CONTROL
+#  ifdef ALLOW_KAPREDI_CONTROL_OLD
+         Kgm_tmp = kapRedi(i,j,k,bi,bj)
+#  else
+         Kgm_tmp = op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i,j,km1,bi,bj))
+#  endif
+#else
+         Kgm_tmp = isopycK*GM_isoFac2d(i,j,bi,bj)
+#endif
+#ifdef ALLOW_KAPGM_CONTROL
+#  ifdef ALLOW_KAPGM_CONTROL_OLD
+     &           + GM_skewflx*kapGM(i,j,k,bi,bj)
+#  else
+     &     + GM_skewflx*op5*(kapGM(i,j,k,bi,bj)+kapGM(i,j,km1,bi,bj))
+#  endif
+#else
+     &           + GM_skewflx*bolus_K*GM_bolFac2d(i,j,bi,bj)
+#endif
+#ifdef GM_VISBECK_VARIABLE_K
+     &           + VisbeckK(i,j,bi,bj)*(1. _d 0 + GM_skewflx)
+#endif
+#ifdef ALLOW_GM_LEITH_QG
+     &           + op5*( GM_LeithQG_K(i,j,k,bi,bj)
+     &                 + GM_LeithQG_K(i,j,km1,bi,bj) )
+     &                *(1. _d 0 + GM_skewflx)
+#endif
+#if ((defined GM_K3D) && ! (defined GM_K3D_PASSIVE))
+     &           + op5*(K3D(i,j,k,bi,bj)+K3D(i,j,km1,bi,bj))
+     &             *(1. _d 0 + GM_skewflx)
+#endif
+         Kwx(i,j,k,bi,bj)= Kgm_tmp*Kwx(i,j,k,bi,bj)
+         Kwy(i,j,k,bi,bj)= Kgm_tmp*Kwy(i,j,k,bi,bj)
+#ifdef ALLOW_KAPREDI_CONTROL
+#  ifdef ALLOW_KAPREDI_CONTROL_OLD
+         Kwz(i,j,k,bi,bj)= ( kapRedi(i,j,k,bi,bj)
+#  else
+         Kwz(i,j,k,bi,bj)= ( op5*(kapRedi(i,j,k,bi,bj)
+     &                            +kapRedi(i,j,km1,bi,bj))
+#  endif
+#else
+         Kwz(i,j,k,bi,bj)= ( isopycK*GM_isoFac2d(i,j,bi,bj)
+#endif
+#ifdef GM_VISBECK_VARIABLE_K
+     &                     + VisbeckK(i,j,bi,bj)
+#endif
+#ifdef ALLOW_GM_LEITH_QG
+     &                     + op5*( GM_LeithQG_K(i,j,k,bi,bj)
+     &                           + GM_LeithQG_K(i,j,km1,bi,bj) )
+#endif
+#if ((defined GM_K3D) && ! (defined GM_K3D_PASSIVE))
+     &                     + op5*(K3D(i,j,k,bi,bj)+K3D(i,j,km1,bi,bj))
+#endif
+     &                     )*Kwz(i,j,k,bi,bj)
+        ENDDO
+       ENDDO
+      ENDDO
+
+#ifdef ALLOW_DIAGNOSTICS
+      IF ( useDiagnostics .AND. GM_taper_scheme.EQ.'fm07' ) THEN
+       CALL DIAGNOSTICS_FILL( hTransLay, 'GM_hTrsL', 0,1,2,bi,bj,myThid)
+       CALL DIAGNOSTICS_FILL( baseSlope, 'GM_baseS', 0,1,2,bi,bj,myThid)
+       CALL DIAGNOSTICS_FILL(recipLambda,'GM_rLamb', 0,1,2,bi,bj,myThid)
+      ENDIF
+#endif /* ALLOW_DIAGNOSTICS */
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C--   Calculate Stream-Functions used in Advective Form:
+
+#ifdef GM_BOLUS_ADVEC
+      IF (GM_AdvForm) THEN
+#ifdef GM_BOLUS_BVP
+       IF (GM_UseBVP) THEN
+        CALL GMREDI_CALC_PSI_BVP(
+     I             bi, bj, iMin, iMax, jMin, jMax,
+     I             sigmaX, sigmaY, sigmaR,
+     I             myThid )
+       ELSE
+#endif
+#ifndef GM_K3D_PASSIVE
+         IF (.NOT. GM_useK3D) THEN
+#endif
+C          If using GM_K3D PsiX and PsiY are calculated in gmredi_k3d
+           CALL GMREDI_CALC_PSI_B(
+     I              bi, bj, iMin, iMax, jMin, jMax,
+     I              sigmaX, sigmaY, sigmaR,
+     I              ldd97_LrhoW, ldd97_LrhoS,
+     I              myThid )
+#ifndef GM_K3D_PASSIVE
+         ENDIF
+#endif
+#ifdef GM_BOLUS_BVP
+       ENDIF
+#endif
+      ENDIF
+#endif
+
+#ifndef GM_EXCLUDE_SUBMESO
+      IF ( GM_useSubMeso .AND. GM_AdvForm ) THEN
+        CALL SUBMESO_CALC_PSI(
+     I              bi, bj, iMin, iMax, jMin, jMax,
+     I              sigmaX, sigmaY, sigmaR,
+     I              locMixLayer,
+     I              myIter, myThid )
+      ENDIF
+#endif /* ndef GM_EXCLUDE_SUBMESO */
+
+#if ( defined (GM_NON_UNITY_DIAGONAL) || defined (GM_EXTRA_DIAGONAL) )
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C-- 2nd  k loop : compute Tensor Coeff. at U point
+
+#ifdef ALLOW_KPP
+      IF ( useKPP ) THEN
+       DO j=1-OLy,sNy+OLy
+        DO i=2-OLx,sNx+OLx
+         locMixLayer(i,j) = ( KPPhbl(i-1,j,bi,bj)
+     &                      + KPPhbl( i ,j,bi,bj) )*op5
+        ENDDO
+       ENDDO
+      ELSE
+#else
+      IF ( .TRUE. ) THEN
+#endif
+       DO j=1-OLy,sNy+OLy
+        DO i=2-OLx,sNx+OLx
+         locMixLayer(i,j) = ( hMixLayer(i-1,j,bi,bj)
+     &                      + hMixLayer( i ,j,bi,bj) )*op5
+        ENDDO
+       ENDDO
+      ENDIF
+      DO j=1-OLy,sNy+OLy
+       DO i=1-OLx,sNx+OLx
+         hTransLay(i,j) =  0.
+         baseSlope(i,j) =  0.
+         recipLambda(i,j)= 0.
+       ENDDO
+       DO i=2-OLx,sNx+OLx
+         hTransLay(i,j) = MAX( R_low(i-1,j,bi,bj), R_low(i,j,bi,bj) )
+       ENDDO
+      ENDDO
+
+      DO k=Nr,1,-1
+       kp1 = MIN(Nr,k+1)
+       maskp1 = 1. _d 0
+       IF (k.GE.Nr) maskp1 = 0. _d 0
+#ifdef ALLOW_AUTODIFF_TAMC
+       kkey = (igmkey-1)*Nr + k
+#endif
+
+C     Gradient of Sigma at U points
+       DO j=1-OLy+1,sNy+OLy-1
+        DO i=1-OLx+1,sNx+OLx-1
+         dSigmaDx(i,j)=sigmaX(i,j,k)
+     &                       *_maskW(i,j,k,bi,bj)
+         dSigmaDy(i,j)=op25*( sigmaY(i-1,j+1,k)+sigmaY(i,j+1,k)
+     &                       +sigmaY(i-1, j ,k)+sigmaY(i, j ,k)
+     &                      )*_maskW(i,j,k,bi,bj)
+         dSigmaDr(i,j)=op25*( sigmaR(i-1,j, k )+sigmaR(i,j, k )
+     &                      +(sigmaR(i-1,j,kp1)+sigmaR(i,j,kp1))*maskp1
+     &                      )*_maskW(i,j,k,bi,bj)
+        ENDDO
+       ENDDO
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE SlopeSqr(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE dSigmaDx(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE dSigmaDy(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE dSigmaDr(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE locMixLayer(:,:)    = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE baseSlope(:,:)      = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE hTransLay(:,:)      = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE recipLambda(:,:)    = comlev1_bibj_k, key=kkey, byte=isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+C     Calculate slopes for use in tensor, taper and/or clip
+       CALL GMREDI_SLOPE_LIMIT(
+     O             SlopeX, SlopeY,
+     O             SlopeSqr, taperFct,
+     U             hTransLay, baseSlope, recipLambda,
+     U             dSigmaDr,
+     I             dSigmaDx, dSigmaDy,
+     I             ldd97_LrhoW, locMixLayer, rC,
+     I             kLow_W,
+     I             k, bi, bj, myTime, myIter, myThid )
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE SlopeSqr(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE taperFct(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+#ifdef GM_NON_UNITY_DIAGONAL
+c      IF ( GM_nonUnitDiag ) THEN
+        DO j=1-OLy+1,sNy+OLy-1
+         DO i=1-OLx+1,sNx+OLx-1
+          Kux(i,j,k,bi,bj) =
+#ifdef ALLOW_KAPREDI_CONTROL
+#  ifdef ALLOW_KAPREDI_CONTROL_OLD
+     &     ( kapRedi(i,j,k,bi,bj)
+#  else
+     &     ( op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i-1,j,k,bi,bj))
+#  endif
+#else
+     &     ( GM_isopycK*GM_isoFac1d(k)
+     &        *op5*(GM_isoFac2d(i-1,j,bi,bj)+GM_isoFac2d(i,j,bi,bj))
+#endif
+#ifdef GM_VISBECK_VARIABLE_K
+     &     +op5*(VisbeckK(i,j,bi,bj)+VisbeckK(i-1,j,bi,bj))
+#endif
+#ifdef ALLOW_GM_LEITH_QG
+     &     +op5*(GM_LeithQG_K(i,j,k,bi,bj)+GM_LeithQG_K(i-1,j,k,bi,bj))
+#endif
+#if ((defined GM_K3D) && ! (defined GM_K3D_PASSIVE))
+     &     +op5*(K3D(i,j,k,bi,bj)+K3D(i-1,j,k,bi,bj))
+#endif
+     &     )*taperFct(i,j)
+         ENDDO
+        ENDDO
+#ifdef ALLOW_AUTODIFF_TAMC
+# ifdef GM_EXCLUDE_CLIPPING
+CADJ STORE Kux(:,:,k,bi,bj)  = comlev1_bibj_k, key=kkey, byte=isbyte
+# endif
+#endif
+        DO j=1-OLy+1,sNy+OLy-1
+         DO i=1-OLx+1,sNx+OLx-1
+          Kux(i,j,k,bi,bj) = MAX( Kux(i,j,k,bi,bj), GM_Kmin_horiz )
+         ENDDO
+        ENDDO
+c      ENDIF
+#endif /* GM_NON_UNITY_DIAGONAL */
+
+#ifdef GM_EXTRA_DIAGONAL
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE SlopeX(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE taperFct(:,:)     = comlev1_bibj_k, key=kkey, byte=isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+       IF ( GM_ExtraDiag ) THEN
+        DO j=1-OLy+1,sNy+OLy-1
+         DO i=1-OLx+1,sNx+OLx-1
+          Kuz(i,j,k,bi,bj) =
+#ifdef ALLOW_KAPREDI_CONTROL
+#  ifdef ALLOW_KAPREDI_CONTROL_OLD
+     &     ( kapRedi(i,j,k,bi,bj)
+#  else
+     &     ( op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i-1,j,k,bi,bj))
+#  endif
+#else
+     &     ( GM_isopycK*GM_isoFac1d(k)
+     &        *op5*(GM_isoFac2d(i-1,j,bi,bj)+GM_isoFac2d(i,j,bi,bj))
+#endif
+#ifdef ALLOW_KAPGM_CONTROL
+#  ifdef ALLOW_KAPGM_CONTROL_OLD
+     &     - GM_skewflx*kapGM(i,j,k,bi,bj)
+#  else
+     &     - GM_skewflx*op5*(kapGM(i,j,k,bi,bj)+kapGM(i-1,j,k,bi,bj))
+#  endif
+#else
+     &     - GM_skewflx*GM_background_K*GM_bolFac1d(k)
+     &        *op5*(GM_bolFac2d(i-1,j,bi,bj)+GM_bolFac2d(i,j,bi,bj))
+#endif
+#ifdef GM_VISBECK_VARIABLE_K
+     &     +op5*(VisbeckK(i,j,bi,bj)+VisbeckK(i-1,j,bi,bj))*GM_advect
+#endif
+#ifdef ALLOW_GM_LEITH_QG
+     &     +op5*( GM_LeithQG_K(i,j,k,bi,bj)
+     &          + GM_LeithQG_K(i-1,j,k,bi,bj) )*GM_advect
+#endif
+#if ((defined GM_K3D) && ! (defined GM_K3D_PASSIVE))
+     &     +op5*(K3D(i,j,k,bi,bj)+K3D(i-1,j,k,bi,bj))*GM_advect
+#endif
+     &     )*SlopeX(i,j)*taperFct(i,j)
+         ENDDO
+        ENDDO
+       ENDIF
+#endif /* GM_EXTRA_DIAGONAL */
+
+#ifdef ALLOW_DIAGNOSTICS
+       IF (doDiagRediFlx) THEN
+        km1 = MAX(k-1,1)
+        DO j=1,sNy
+         DO i=1,sNx+1
+C         store in tmp1k Kuz_Redi
+#ifdef ALLOW_KAPREDI_CONTROL
+#  ifdef ALLOW_KAPREDI_CONTROL_OLD
+          tmp1k(i,j) = ( kapRedi(i,j,k,bi,bj)
+#  else
+          tmp1k(i,j) = ( op5*(kapRedi(i-1,j,k,bi,bj)
+     &                       +kapRedi(i,j,k,bi,bj))
+#  endif
+#else
+          tmp1k(i,j) = ( GM_isopycK*GM_isoFac1d(k)
+     &        *op5*(GM_isoFac2d(i-1,j,bi,bj)+GM_isoFac2d(i,j,bi,bj))
+#endif
+#ifdef GM_VISBECK_VARIABLE_K
+     &     +op5*(VisbeckK(i,j,bi,bj)+VisbeckK(i-1,j,bi,bj))
+#endif
+#ifdef ALLOW_GM_LEITH_QG
+     &     +op5*( GM_LeithQG_K(i,j,k,bi,bj)
+     &          + GM_LeithQG_K(i-1,j,k,bi,bj) )
+#endif
+#if ((defined GM_K3D) && ! (defined GM_K3D_PASSIVE))
+     &     +op5*(K3D(i,j,k,bi,bj)+K3D(i-1,j,k,bi,bj))
+#endif
+     &                 )*SlopeX(i,j)*taperFct(i,j)
+         ENDDO
+        ENDDO
+        DO j=1,sNy
+         DO i=1,sNx+1
+C-        Vertical gradients interpolated to U points
+          dTdz = (
+     &     +recip_drC(k)*
+     &       ( maskC(i-1,j,k,bi,bj)*
+     &           (theta(i-1,j,km1,bi,bj)-theta(i-1,j,k,bi,bj))
+     &        +maskC( i ,j,k,bi,bj)*
+     &           (theta( i ,j,km1,bi,bj)-theta( i ,j,k,bi,bj))
+     &       )
+     &     +recip_drC(kp1)*
+     &       ( maskC(i-1,j,kp1,bi,bj)*
+     &           (theta(i-1,j,k,bi,bj)-theta(i-1,j,kp1,bi,bj))
+     &        +maskC( i ,j,kp1,bi,bj)*
+     &           (theta( i ,j,k,bi,bj)-theta( i ,j,kp1,bi,bj))
+     &       )      ) * 0.25 _d 0
+           tmp1k(i,j) = dyG(i,j,bi,bj)*drF(k)
+     &                * _hFacW(i,j,k,bi,bj)
+     &                * tmp1k(i,j) * dTdz
+         ENDDO
+        ENDDO
+        CALL DIAGNOSTICS_FILL(tmp1k, 'GM_KuzTz', k,1,2,bi,bj,myThid)
+       ENDIF
+#endif /* ALLOW_DIAGNOSTICS */
+
+C-- end 2nd  loop on vertical level index k
+      ENDDO
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C-- 3rd  k loop : compute Tensor Coeff. at V point
+
+#ifdef ALLOW_KPP
+      IF ( useKPP ) THEN
+       DO j=2-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+         locMixLayer(i,j) = ( KPPhbl(i,j-1,bi,bj)
+     &                      + KPPhbl(i, j ,bi,bj) )*op5
+        ENDDO
+       ENDDO
+      ELSE
+#else
+      IF ( .TRUE. ) THEN
+#endif
+       DO j=2-OLy,sNy+OLy
+        DO i=1-OLx,sNx+OLx
+         locMixLayer(i,j) = ( hMixLayer(i,j-1,bi,bj)
+     &                      + hMixLayer(i, j ,bi,bj) )*op5
+        ENDDO
+       ENDDO
+      ENDIF
+      DO j=1-OLy,sNy+OLy
+       DO i=1-OLx,sNx+OLx
+         hTransLay(i,j) =  0.
+         baseSlope(i,j) =  0.
+         recipLambda(i,j)= 0.
+       ENDDO
+      ENDDO
+      DO j=2-OLy,sNy+OLy
+       DO i=1-OLx,sNx+OLx
+         hTransLay(i,j) = MAX( R_low(i,j-1,bi,bj), R_low(i,j,bi,bj) )
+       ENDDO
+      ENDDO
+
+C     Gradient of Sigma at V points
+      DO k=Nr,1,-1
+       kp1 = MIN(Nr,k+1)
+       maskp1 = 1. _d 0
+       IF (k.GE.Nr) maskp1 = 0. _d 0
+#ifdef ALLOW_AUTODIFF_TAMC
+       kkey = (igmkey-1)*Nr + k
+#endif
+
+       DO j=1-OLy+1,sNy+OLy-1
+        DO i=1-OLx+1,sNx+OLx-1
+         dSigmaDx(i,j)=op25*( sigmaX(i, j ,k) +sigmaX(i+1, j ,k)
+     &                       +sigmaX(i,j-1,k) +sigmaX(i+1,j-1,k)
+     &                      )*_maskS(i,j,k,bi,bj)
+         dSigmaDy(i,j)=sigmaY(i,j,k)
+     &                       *_maskS(i,j,k,bi,bj)
+         dSigmaDr(i,j)=op25*( sigmaR(i,j-1, k )+sigmaR(i,j, k )
+     &                      +(sigmaR(i,j-1,kp1)+sigmaR(i,j,kp1))*maskp1
+     &                      )*_maskS(i,j,k,bi,bj)
+        ENDDO
+       ENDDO
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE dSigmaDx(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE dSigmaDy(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE dSigmaDr(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE baseSlope(:,:)      = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE hTransLay(:,:)      = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE recipLambda(:,:)    = comlev1_bibj_k, key=kkey, byte=isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+
+C     Calculate slopes for use in tensor, taper and/or clip
+       CALL GMREDI_SLOPE_LIMIT(
+     O             SlopeX, SlopeY,
+     O             SlopeSqr, taperFct,
+     U             hTransLay, baseSlope, recipLambda,
+     U             dSigmaDr,
+     I             dSigmaDx, dSigmaDy,
+     I             ldd97_LrhoS, locMixLayer, rC,
+     I             kLow_S,
+     I             k, bi, bj, myTime, myIter, myThid )
+
+cph(
+#ifdef ALLOW_AUTODIFF_TAMC
+cph(
+CADJ STORE taperfct(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+cph)
+#endif /* ALLOW_AUTODIFF_TAMC */
+cph)
+
+#ifdef GM_NON_UNITY_DIAGONAL
+c      IF ( GM_nonUnitDiag ) THEN
+        DO j=1-OLy+1,sNy+OLy-1
+         DO i=1-OLx+1,sNx+OLx-1
+          Kvy(i,j,k,bi,bj) =
+#ifdef ALLOW_KAPREDI_CONTROL
+#  ifdef ALLOW_KAPREDI_CONTROL_OLD
+     &     ( kapRedi(i,j,k,bi,bj)
+#  else
+     &     ( op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i,j-1,k,bi,bj))
+#  endif
+#else
+     &     ( GM_isopycK*GM_isoFac1d(k)
+     &        *op5*(GM_isoFac2d(i,j-1,bi,bj)+GM_isoFac2d(i,j,bi,bj))
+#endif
+#ifdef GM_VISBECK_VARIABLE_K
+     &     +op5*(VisbeckK(i,j,bi,bj)+VisbeckK(i,j-1,bi,bj))
+#endif
+#ifdef ALLOW_GM_LEITH_QG
+     &     +op5*(GM_LeithQG_K(i,j,k,bi,bj)+GM_LeithQG_K(i,j-1,k,bi,bj))
+#endif
+#if ((defined GM_K3D) && ! (defined GM_K3D_PASSIVE))
+     &     +op5*(K3D(i,j,k,bi,bj)+K3D(i,j-1,k,bi,bj))
+#endif
+     &     )*taperFct(i,j)
+         ENDDO
+        ENDDO
+#ifdef ALLOW_AUTODIFF_TAMC
+# ifdef GM_EXCLUDE_CLIPPING
+CADJ STORE Kvy(:,:,k,bi,bj)  = comlev1_bibj_k, key=kkey, byte=isbyte
+# endif
+#endif
+        DO j=1-OLy+1,sNy+OLy-1
+         DO i=1-OLx+1,sNx+OLx-1
+          Kvy(i,j,k,bi,bj) = MAX( Kvy(i,j,k,bi,bj), GM_Kmin_horiz )
+         ENDDO
+        ENDDO
+c      ENDIF
+#endif /* GM_NON_UNITY_DIAGONAL */
+
+#ifdef GM_EXTRA_DIAGONAL
+
+#ifdef ALLOW_AUTODIFF_TAMC
+CADJ STORE SlopeY(:,:)       = comlev1_bibj_k, key=kkey, byte=isbyte
+CADJ STORE taperFct(:,:)     = comlev1_bibj_k, key=kkey, byte=isbyte
+#endif /* ALLOW_AUTODIFF_TAMC */
+       IF ( GM_ExtraDiag ) THEN
+        DO j=1-OLy+1,sNy+OLy-1
+         DO i=1-OLx+1,sNx+OLx-1
+          Kvz(i,j,k,bi,bj) =
+#ifdef ALLOW_KAPREDI_CONTROL
+#  ifdef ALLOW_KAPREDI_CONTROL_OLD
+     &     ( kapRedi(i,j,k,bi,bj)
+#  else
+     &     ( op5*(kapRedi(i,j,k,bi,bj)+kapRedi(i,j-1,k,bi,bj))
+#  endif
+#else
+     &     ( GM_isopycK*GM_isoFac1d(k)
+     &        *op5*(GM_isoFac2d(i,j-1,bi,bj)+GM_isoFac2d(i,j,bi,bj))
+#endif
+#ifdef ALLOW_KAPGM_CONTROL
+#  ifdef ALLOW_KAPGM_CONTROL_OLD
+     &     - GM_skewflx*kapGM(i,j,k,bi,bj)
+#  else
+     &     - GM_skewflx*op5*(kapGM(i,j,k,bi,bj)+kapGM(i,j-1,k,bi,bj))
+#  endif
+#else
+     &     - GM_skewflx*GM_background_K*GM_bolFac1d(k)
+     &        *op5*(GM_bolFac2d(i,j-1,bi,bj)+GM_bolFac2d(i,j,bi,bj))
+#endif
+#ifdef GM_VISBECK_VARIABLE_K
+     &     +op5*(VisbeckK(i,j,bi,bj)+VisbeckK(i,j-1,bi,bj))*GM_advect
+#endif
+#ifdef ALLOW_GM_LEITH_QG
+     &     +op5*( GM_LeithQG_K(i,j,k,bi,bj)
+     &          + GM_LeithQG_K(i,j-1,k,bi,bj) )*GM_advect
+#endif
+#if ((defined GM_K3D) && ! (defined GM_K3D_PASSIVE))
+     &     +op5*(K3D(i,j,k,bi,bj)+K3D(i,j-1,k,bi,bj))*GM_advect
+#endif
+     &     )*SlopeY(i,j)*taperFct(i,j)
+         ENDDO
+        ENDDO
+       ENDIF
+#endif /* GM_EXTRA_DIAGONAL */
+
+#ifdef ALLOW_DIAGNOSTICS
+       IF (doDiagRediFlx) THEN
+        km1 = MAX(k-1,1)
+        DO j=1,sNy+1
+         DO i=1,sNx
+C         store in tmp1k Kvz_Redi
+#ifdef ALLOW_KAPREDI_CONTROL
+#  ifdef ALLOW_KAPREDI_CONTROL_OLD
+          tmp1k(i,j) = ( kapRedi(i,j,k,bi,bj)
+#  else
+          tmp1k(i,j) = ( op5*(kapRedi(i,j-1,k,bi,bj)
+     &                       +kapRedi(i,j,k,bi,bj))
+#  endif
+#else
+          tmp1k(i,j) = ( GM_isopycK*GM_isoFac1d(k)
+     &        *op5*(GM_isoFac2d(i,j-1,bi,bj)+GM_isoFac2d(i,j,bi,bj))
+#endif
+#ifdef GM_VISBECK_VARIABLE_K
+     &     +op5*(VisbeckK(i,j,bi,bj)+VisbeckK(i,j-1,bi,bj))
+#endif
+#ifdef ALLOW_GM_LEITH_QG
+     &     +op5*( GM_LeithQG_K(i,j,k,bi,bj)
+     &          + GM_LeithQG_K(i,j-1,k,bi,bj) )
+#endif
+#if ((defined GM_K3D) && ! (defined GM_K3D_PASSIVE))
+     &     +op5*(K3D(i,j,k,bi,bj)+K3D(i,j-1,k,bi,bj))
+#endif
+     &                 )*SlopeY(i,j)*taperFct(i,j)
+         ENDDO
+        ENDDO
+        DO j=1,sNy+1
+         DO i=1,sNx
+C-        Vertical gradients interpolated to U points
+          dTdz = (
+     &     +recip_drC(k)*
+     &       ( maskC(i,j-1,k,bi,bj)*
+     &           (theta(i,j-1,km1,bi,bj)-theta(i,j-1,k,bi,bj))
+     &        +maskC(i, j ,k,bi,bj)*
+     &           (theta(i, j ,km1,bi,bj)-theta(i, j ,k,bi,bj))
+     &       )
+     &     +recip_drC(kp1)*
+     &       ( maskC(i,j-1,kp1,bi,bj)*
+     &           (theta(i,j-1,k,bi,bj)-theta(i,j-1,kp1,bi,bj))
+     &        +maskC(i, j ,kp1,bi,bj)*
+     &           (theta(i, j ,k,bi,bj)-theta(i, j ,kp1,bi,bj))
+     &       )      ) * 0.25 _d 0
+           tmp1k(i,j) = dxG(i,j,bi,bj)*drF(k)
+     &                * _hFacS(i,j,k,bi,bj)
+     &                * tmp1k(i,j) * dTdz
+         ENDDO
+        ENDDO
+        CALL DIAGNOSTICS_FILL(tmp1k, 'GM_KvzTz', k,1,2,bi,bj,myThid)
+       ENDIF
+#endif /* ALLOW_DIAGNOSTICS */
+
+C-- end 3rd  loop on vertical level index k
+      ENDDO
+
+#endif /* GM_NON_UNITY_DIAGONAL || GM_EXTRA_DIAGONAL */
+
+#ifdef ALLOW_TIMEAVE
+C--   Time-average
+      IF ( taveFreq.GT.0. ) THEN
+
+         CALL TIMEAVE_CUMULATE( GM_Kwx_T, Kwx, Nr,
+     &                          deltaTclock, bi, bj, myThid )
+         CALL TIMEAVE_CUMULATE( GM_Kwy_T, Kwy, Nr,
+     &                          deltaTclock, bi, bj, myThid )
+         CALL TIMEAVE_CUMULATE( GM_Kwz_T, Kwz, Nr,
+     &                          deltaTclock, bi, bj, myThid )
+#ifdef GM_VISBECK_VARIABLE_K
+       IF ( GM_Visbeck_alpha.NE.0. ) THEN
+         CALL TIMEAVE_CUMULATE( Visbeck_K_T, VisbeckK, 1,
+     &                          deltaTclock, bi, bj, myThid )
+       ENDIF
+#endif
+#ifdef GM_BOLUS_ADVEC
+       IF ( GM_AdvForm ) THEN
+         CALL TIMEAVE_CUMULATE( GM_PsiXtave, GM_PsiX, Nr,
+     &                          deltaTclock, bi, bj, myThid )
+         CALL TIMEAVE_CUMULATE( GM_PsiYtave, GM_PsiY, Nr,
+     &                          deltaTclock, bi, bj, myThid )
+       ENDIF
+#endif
+       GM_timeAve(bi,bj) = GM_timeAve(bi,bj)+deltaTclock
+
+      ENDIF
+#endif /* ALLOW_TIMEAVE */
+
+#ifdef ALLOW_DIAGNOSTICS
+      IF ( useDiagnostics ) THEN
+        CALL GMREDI_DIAGNOSTICS_FILL(bi,bj,myThid)
+      ENDIF
+#endif /* ALLOW_DIAGNOSTICS */
+
+#endif /* ALLOW_GMREDI */
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+CBOP
+C     !ROUTINE: GMREDI_CALC_TENSOR_DUMMY
+C     !INTERFACE:
+      SUBROUTINE GMREDI_CALC_TENSOR_DUMMY(
+     I             iMin, iMax, jMin, jMax,
+     I             sigmaX, sigmaY, sigmaR,
+     I             bi, bj, myTime, myIter, myThid )
+
+C     !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SUBROUTINE GMREDI_CALC_TENSOR_DUMMY
+C     | o Calculate tensor elements for GM/Redi tensor.
+C     *==========================================================*
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == Global variables ==
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "GMREDI.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+      _RL sigmaX(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL sigmaY(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      _RL sigmaR(1-OLx:sNx+OLx,1-OLy:sNy+OLy,Nr)
+      INTEGER iMin,iMax,jMin,jMax
+      INTEGER bi, bj
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
+CEOP
+
+#ifdef ALLOW_GMREDI
+C     !LOCAL VARIABLES:
+      INTEGER i, j, k
+
+      DO k=1,Nr
+       DO j=1-OLy+1,sNy+OLy-1
+        DO i=1-OLx+1,sNx+OLx-1
+         Kwx(i,j,k,bi,bj) = 0.0
+         Kwy(i,j,k,bi,bj) = 0.0
+         Kwz(i,j,k,bi,bj) = 0.0
+        ENDDO
+       ENDDO
+      ENDDO
+#endif /* ALLOW_GMREDI */
+
+      RETURN
+      END

--- a/devel/V4r5_devel/code/gmredi_xtransport.F
+++ b/devel/V4r5_devel/code/gmredi_xtransport.F
@@ -158,7 +158,8 @@ C-    Vertical gradients interpolated to U points
        DO j=jMin,jMax
         DO i=iMin,iMax
 #ifdef ALLOW_SHELFICE
-           if (k-1 .ge. kTopC(i,j,bi,bj)) then
+           if (k-1 .ge. kTopC(i,j,bi,bj).and.
+     &         k-1 .ge. kTopC(i-1,j,bi,bj)) then
 #endif /* ALLOW_SHELFICE */
         dTdz(i,j) =  op5*(
      &   +op5*recip_drC(k)*

--- a/devel/V4r5_devel/code/gmredi_ytransport.F
+++ b/devel/V4r5_devel/code/gmredi_ytransport.F
@@ -156,7 +156,8 @@ C-    Vertical gradients interpolated to V points
        DO j=jMin,jMax
         DO i=iMin,iMax
 #ifdef ALLOW_SHELFICE
-           if (k-1 .ge. kTopC(i,j,bi,bj)) then
+           if (k-1 .ge. kTopC(i,j,bi,bj).and.
+     &         k-1 .ge. kTopC(i,j-1,bi,bj)) then
 #endif /* ALLOW_SHELFICE */
         dTdz(i,j) =  op5*(
      &   +op5*recip_drC(k)*


### PR DESCRIPTION
A big fix to restore stratification inside ice cavities. The bug is related to ggl90 and gmredi code that incorrectly uses values inside ice (dry points) for some of ceiling points of ice shelves.