### PR TITLE
Add new build option file and update data.diagnostics for V4r4

### DIFF
--- a/ECCOv4 Release 4/code/linux_amd64_ifort+mpi_ice_nas
+++ b/ECCOv4 Release 4/code/linux_amd64_ifort+mpi_ice_nas
@@ -1,0 +1,88 @@
+#! /usr/bin/env bash
+
+# Used to run testreport on pleiades after OS changed from SLES to TOSS (v.3),
+# using either recent intel compiler:
+#   > module load comp-intel/2020.4.304
+# or using older intel compiler:
+#   > module load comp-intel/2016.2.181
+#- and, with MPI:
+#   > module load mpi-hpe/mpt.2.25
+#   > module load hdf4/4.2.12 hdf5/1.8.18_mpt netcdf/4.4.1.1_mpt
+#- and without:
+#   > module load hdf4/4.2.12 hdf5/1.8.18_serial netcdf/4.4.1.1_serial
+#- Note: in both cases, the last line of 3 module setting is for NetCDF
+#        (could be skipped if not using at all this type of I/O).
+
+FC=ifort
+CC=icc
+
+CPP='/lib/cpp -traditional -P'
+DEFINES='-DWORDLENGTH=4 -DINTEL_COMMITQQ'
+F90FIXEDFORMAT='-fixed -Tf'
+EXTENDED_SRC_FLAG='-132'
+GET_FC_VERSION="--version"
+OMPFLAG='-openmp'
+
+#NOOPTFLAGS='-O1 -fp-model precise'
+NOOPTFLAGS='-O0'
+NOOPTFILES=''
+
+CFLAGS='-O0'
+FFLAGS="$FFLAGS -convert big_endian -assume byterecl"
+
+#- for big setups, compile & link with "-fPIC" or set memory-model to "medium":
+CFLAGS="$CFLAGS -fPIC"
+FFLAGS="$FFLAGS -fPIC"
+#- For really big executable (> 2 GB), uncomment following 2 lines
+#FFLAGS="$FFLAGS -mcmodel=medium -shared-intel"
+#CFLAGS="$CFLAGS -mcmodel=medium -shared-intel"
+#- might want to use '-r8' for fizhi pkg:
+#FFLAGS="$FFLAGS -r8"
+
+LDADD='-shared-intel'
+
+FFLAGS="$FFLAGS -W0 -WB"
+if test "x$IEEE" = x ; then     #- with optimisation:
+    FOPTIM='-O2 -ipo -fp-model precise -align -axCORE-AVX2 -xSSE4.2 -traceback -ftz'
+    NOOPTFILES='seaice_growth.F calc_oce_mxlayer.F fizhi_lsm.F fizhi_clockstuff.F ini_parms.F'
+    NOOPTFILES="$NOOPTFILES obcs_init_fixed.F"
+else
+  if test "x$DEVEL" = x ; then  #- no optimisation + IEEE :
+    FOPTIM='-O0 -noalign'
+  else                          #- development/check options:
+   #FFLAGS="$FFLAGS -debug all -debug-parameters all -fp-model strict"
+    FOPTIM="-O0 -noalign -g -traceback"
+    NOOPTFLAGS=$FOPTIM
+    NOOPTFILES='adread_adwrite.F mdsio_rw_field.F mdsio_rw_slice.F'
+    FOPTIM="$FOPTIM -warn all -warn nounused"
+    FOPTIM="$FOPTIM -fpe0 -ftz -fp-stack-check -check all -ftrapuv"
+  fi
+fi
+
+F90FLAGS=$FFLAGS
+F90OPTIM=$FOPTIM
+
+INCLUDEDIRS=''
+INCLUDES=''
+LIBS=''
+
+if [ -n "$MPI_ROOT" -a "x$MPI" = xtrue ] ; then
+    if [ -z "$MPI_INC_DIR" ]; then
+      MPI_INC_DIR="${MPI_ROOT}/include"
+    fi
+    LIBS="$LIBS -L${MPI_ROOT}/lib -lmpi"
+fi
+
+if [ -n "$MPI_INC_DIR" -a "x$MPI" = xtrue ] ; then
+    INCLUDES="$INCLUDES -I${MPI_INC_DIR}"
+    #INCLUDEDIRS="$INCLUDEDIRS $MPI_INC_DIR"
+    #- used for parallel (MPI) DIVA
+    MPIINCLUDEDIR="$MPI_INC_DIR"
+    #MPI_HEADER_FILES='mpif.h mpiof.h'
+fi
+
+if [ "x$NETCDF" != x ] ; then
+    INCLUDES="$INCLUDES -I${NETCDF}/include"
+    #INCLUDEDIRS="$INCLUDEDIRS ${NETCDF}/include"
+    LIBS="$LIBS -L${NETCDF}/lib"
+fi

--- a/ECCOv4 Release 4/namelist/data.diagnostics
+++ b/ECCOv4 Release 4/namelist/data.diagnostics
@@ -371,6 +371,22 @@ frequency(96) = 2635200.0,
 fields(1,96) = 'EXFpress',
 filename(96) = 'diags/EXFpress_mon_mean/EXFpress_mon_mean',
 #---
+frequency(97) = 2635200.0,
+fields(1,97) = 'SIacSubl',
+filename(97) = 'diags/SIacSubl_mon_mean/SIacSubl_mon_mean',
+#---
+frequency(98) = 2635200.0,
+fields(1,98) = 'SIaaflux',
+filename(98) = 'diags/SIaaflux_mon_mean/SIaaflux_mon_mean',
+#---
+frequency(99) = 2635200.0,
+fields(1,99) = 'SIfwThru',
+filename(99) = 'diags/SIfwThru_mon_mean/SIfwThru_mon_mean',
+#---
+frequency(100) = 2635200.0,
+fields(1,100) = 'SIrsSubl',
+filename(100) = 'diags/SIrsSubl_mon_mean/SIrsSubl_mon_mean',
+#---
   /
 #
 #


### PR DESCRIPTION
Updates are only for V4r4

- Add a new version (from MITgcm checkpoint 68f) of the build option file linux_amd64_ifort+mpi_ice_nas. This version drops particular module names and thus is more general.
- Make the namelist file data.diagnostics the same as data.diagnostics.monthly.inddiag. 