### PR TITLE
Add data.ctrl.restart

### DIFF
--- a/ECCOv4 Release 4/namelist/data.ctrl.restart
+++ b/ECCOv4 Release 4/namelist/data.ctrl.restart
@@ -1,0 +1,52 @@
+# *********************
+# ECCO controlvariables
+# *********************
+ &ctrl_nml
+#
+ doSinglePrecTapelev=.TRUE.,
+ ctrlSmoothCorrel2D=.TRUE.,
+ ctrlSmoothCorrel3D=.TRUE.,
+  ctrlUseGen=.TRUE.,
+#to start from given xx*00.data files
+  doinitxx = .FALSE.,
+  doMainUnpack = .FALSE.,
+#to start from given ecco_ctrl... files
+# doinitxx = .FALSE.,
+#
+#doPackDiag = .TRUE.,
+ forcingPrecond=1.,
+/
+
+#
+# *********************
+# names for ctrl_pack/unpack
+# *********************
+ &ctrl_packnames
+ /
+#
+# *********************
+# names for CTRL_GENARR, CTRL_GENTIM
+# *********************
+ &CTRL_NML_GENARR
+ xx_genarr3d_weight(3) = 'r2.wkapgmFldv2.data',
+ xx_genarr3d_file(3)='xx_kapgm',
+ xx_genarr3d_bounds(1:5,3)=1.E2,2.E2,0.9E4,1.E4,0.,
+ xx_genarr3d_preproc(1,3)='WC01',
+ xx_genarr3d_preproc_i(1,3)=1,
+ mult_genarr3d(3) = 1.,
+#
+ xx_genarr3d_weight(4) = 'r2.wkaprediFldv2.data',
+ xx_genarr3d_file(4)='xx_kapredi',
+ xx_genarr3d_bounds(1:5,4)=1.E2,2.E2,0.9E4,1.E4,0.,
+ xx_genarr3d_preproc(1,4)='WC01',
+ xx_genarr3d_preproc_i(1,4)=1,
+ mult_genarr3d(4) = 1.,
+#
+ xx_genarr3d_weight(5) = 'r2.wdiffkrFldv2.data',
+ xx_genarr3d_file(5)='xx_diffkr',
+ xx_genarr3d_bounds(1:5,5)=1.E-6,2.E-6,4.E-4,5.E-4,0.,
+ xx_genarr3d_preproc(1,5)='WC01',
+ xx_genarr3d_preproc_i(1,5)=1,
+ mult_genarr3d(5) = 1.,
+
+ /


### PR DESCRIPTION
Add data.ctrl.restart that should be used as the data.ctrl namelist if a run is restarted from a time instant other than 01/01/1992, 12Z. The data.ctrl.restart removes control variables for initial UVTS and SSH as the control adjustments of these variables are not needed if the run does not start at 12Z, 01/01/1992.