### PR TITLE
A few updates

### DIFF
--- a/devel/V4r5_devel/README
+++ b/devel/V4r5_devel/README
@@ -1,5 +1,5 @@
 - This directory contains the development version of the ECCO Version 4, Release 5 configuration. 
-  The patch code is based on MITgcm checkpoint68d. 
+  The patch code is based on MITgcm checkpoint68g. 
   README                              This file
   code                                Patch code 
   input                               Namelists 
@@ -11,5 +11,6 @@
 README file revision history:
 -----------------------------
 
+- Update codebase from 68d to 68g                  [Ou Wang] [2022/03/03]
 - Update codebase from 67l to 68d                  [Ou Wang] [2022/01/30]
 - README file creation                             [Ou Wang] [2020/06/10]

--- a/devel/V4r5_devel/code/CPP_OPTIONS.h
+++ b/devel/V4r5_devel/code/CPP_OPTIONS.h
@@ -72,7 +72,7 @@ C o Include pressure loading code
 C o Calculate Phi-Hydrostatic at r-lower boundary during initialization.
 C   Needed for obp cost. Otherwise, the first record of m_bp is wrong,
 C   because phiHydLow is zero.
-#undef CALC_PHI_RLOW_INI
+#define CALC_PHI_RLOW_INI
 
 C o exclude/allow external forcing-fields load
 C   this allows to read & do simple linear time interpolation of oceanic

--- a/devel/V4r5_devel/code/MITgcm_codebase
+++ b/devel/V4r5_devel/code/MITgcm_codebase
@@ -1,2 +1,2 @@
-20220121
-MITgcm checkpoint 68d
+20220217
+MITgcm checkpoint 68g

--- a/devel/V4r5_devel/code/initialise_varia.F
+++ b/devel/V4r5_devel/code/initialise_varia.F
@@ -117,6 +117,13 @@ CEOP
       IF (debugMode) CALL DEBUG_ENTER('INITIALISE_VARIA',myThid)
 #endif
 
+#ifdef CALC_PHI_RLOW_INI
+      iMin = 1-OLx
+      iMax = sNx+OLx
+      jMin = 1-OLy
+      jMax = sNy+OLy
+#endif
+
 #ifdef ALLOW_AUTODIFF
       nIter0 = NINT( (startTime-baseTime)/deltaTClock )
 #endif /* ALLOW_AUTODIFF */
@@ -160,26 +167,6 @@ C     stored files.
 CADJ STORE phi0surf = tapelev_init, key = 1
 #endif
       CALL INI_FIELDS( myThid )
-#ifdef CALC_PHI_RLOW_INI
-Cow
-C--      Integrate hydrostatic balance for phiHyd with BC of phiHyd(z=0)=0
-C--      phiHydLow is calcluated here using the initial TS and will
-C--      be used in ecco_phys.F (called in ECCO_INIT_VARIA.F/PACKAGES_INIT_VARIABLES.F).
-C--      to correct m_bp. Otherwise, a zero phiHydLow will be used, which
-C--      is incorrect.
-C--
-      DO bj = myByLo(myThid), myByHi(myThid)
-       DO bi = myBxLo(myThid), myBxHi(myThid)
-        DO k = 1, Nr
-         CALL CALC_PHI_HYD(
-     I        bi,bj,iMin,iMax,jMin,jMax,k,
-     U        phiHydF,
-     O        phiHydC, dPhiHydX, dPhiHydY,
-     I        startTime, -1, myThid )
-        ENDDO
-       ENDDO
-      ENDDO
-#endif
 
 C--   Initialise 3-dim. diffusivities
 #ifdef ALLOW_DEBUG
@@ -201,6 +188,27 @@ C--   Initialise model forcing fields.
 #ifdef ALLOW_AUTODIFF
 C--   Initialise active fields to help TAMC
       if (useAUTODIFF) CALL AUTODIFF_INIT_VARIA( myThid )
+#endif
+
+#ifdef CALC_PHI_RLOW_INI
+Cow
+C--      Integrate hydrostatic balance for phiHyd with BC of phiHyd(z=0)=0
+C--      phiHydLow is calcluated here using the initial TS and will
+C--      be used in ecco_phys.F (called in ECCO_INIT_VARIA.F/PACKAGES_INIT_VARIABLES.F).
+C--      to correct m_bp. Otherwise, a zero phiHydLow will be used, which
+C--      is incorrect.
+C--
+      DO bj = myByLo(myThid), myByHi(myThid)
+       DO bi = myBxLo(myThid), myBxHi(myThid)
+        DO k = 1, Nr
+         CALL CALC_PHI_HYD_TEST(
+     I        bi,bj,iMin,iMax,jMin,jMax,k,
+     U        phiHydF,
+     O        phiHydC, dPhiHydX, dPhiHydY,
+     I        startTime, -1, myThid )
+        ENDDO
+       ENDDO
+      ENDDO
 #endif
 
 C--   Initialize variable data for packages

--- a/devel/V4r5_devel/code/shelfice_solve4fluxes.F
+++ b/devel/V4r5_devel/code/shelfice_solve4fluxes.F
@@ -253,7 +253,7 @@ C--   consists of only two terms: turbulent fluxes (positive out)
 C--   and advective meltwater fluxes (negative in).
              heatFlux = rUnit2mass*HeatCapacity_Cp * (
      &           gammaT * (insitutLoc - thetaFreeze) 
-     &           + w_B * thetaFreeze                 )
+     &           + w_B * (thetaFreeze - insitutLoc + tLoc) )
           ELSE
 
 C--   If the volume is fixed (realFWFlux=false) then the advection of

--- a/devel/V4r5_devel/code/shelfice_thermodynamics.F
+++ b/devel/V4r5_devel/code/shelfice_thermodynamics.F
@@ -73,8 +73,8 @@ C                         to melting in kg/m^2/s
 C                         (negative density x melt rate)
 C     iceFrontCellThickness   :: the ratio of the grid cell area to
 C                         the horizontal length of the ice front.
-C                         unit meters.  Approximately the length of the 
-C                         column perpendicular to the ice front extended 
+C                         unit meters.  Approximately the length of the
+C                         column perpendicular to the ice front extended
 C                         to the far side of the tracer cell.
 C     iceFrontWidth    :: the width of the ice front.  unit meters.
 
@@ -359,7 +359,7 @@ C--   In units W/m^2
      &                    tmpHeatFluxscaled
 
 C     In units of kg/s/m^2
-                        tmpFWFLXscaled = 
+                        tmpFWFLXscaled =
      &                    tmpFWFLX*iceFrontVertContactFrac
      &                    *icfgridareaFrac
                         iceFrontFreshWaterFlux(CURI,CURJ,K,bi,bj) = 
@@ -377,8 +377,8 @@ C ow -  with Rignot's data
                         SHIICFHeatFlux(CURI,CURJ,bi,bj) = 
      &                   SHIICFHeatFlux(CURI,CURJ,bi,bj) + 
      &                   tmpHeatFluxscaled
-                        SHIICFFreshWaterFlux(CURI,CURJ,bi,bj) = 
-     &                   SHIICFFreshWaterFlux(CURI,CURJ,bi,bj) + 
+                        SHIICFFreshWaterFlux(CURI,CURJ,bi,bj) =
+     &                   SHIICFFreshWaterFlux(CURI,CURJ,bi,bj) +
      &                   tmpFWFLXscaled
                    endif
                   endif
@@ -402,8 +402,8 @@ C     In units of K / s
      &                    DRF(k)
 
 C     In units of psu /s
-                        iceFrontForcingS(CURI,CURJ,K,bi,bj) = 
-     &                    iceFrontForcingS(CURI,CURJ,K,bi,bj) + 
+                        iceFrontForcingS(CURI,CURJ,K,bi,bj) =
+     &                    iceFrontForcingS(CURI,CURJ,K,bi,bj) +
      &                    tmpForcingS/iceFrontCellThickness*
      &                    iceFrontVertContactFrac*
      &                    _recip_hFacC(CURI,CURJ,K,bi,bj)


### PR DESCRIPTION
Bring codebase from 68d to 68g (so TS budgets can be closed because of bug fixes in pkg/gmredi (see MITgcm Pull Request [#593](https://github.com/MITgcm/MITgcm/pull/593)).

Reformulate heat flux due to ice shelf/front melt. This would result in having better closure of heat budget. 

Calculate phiHydLow during initialization by default so the first time record of OBP would be correct. Otherwise, ecco_phys.F would use phiHydLow=0 when calculating the first time record of OBP.