### PR TITLE
bash scripts to automate V4r4 code get (eget) and ancillary data down…

### DIFF
--- a/ECCOv4 Release 4/scripts/eadd
+++ b/ECCOv4 Release 4/scripts/eadd
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# eadd - ECCO Ancillary Data Download
+#
+
+# configuration (perhaps cfg/ENV at some point):
+v=4; r=4
+rooturl="https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-protected/ECCO_L4_ANCILLARY_DATA_V${v}R${r}"
+
+usage() {
+    echo "$(basename $0) - ECCO V${v}r${r} ancillary data download, extract and, optionally, clean up"
+    echo "usage: $(basename $0) [-u username] [-p password] [-k]"
+    echo "where:"
+    echo "    -u    NASA Earthdata username (prompt if not provided)"
+    echo "    -p    NASA Earthdata password (prompt if not provided)"
+    echo "    -k    Keep downloaded tarfiles after extraction"
+    echo "note: $(basename $0) is called by the eget utility"
+}
+version() { echo "1.0"; }
+
+keep=no
+while getopts ":u:p:hkv" opt; do
+    case $opt in
+        k  ) keep=yes ;;
+        u  ) uname=$OPTARG ;;
+        p  ) passwd=$OPTARG ;;
+        h  ) usage
+             exit 1 ;;
+        v  ) version
+             exit 1 ;;
+        \? ) usage
+             exit 1 ;;
+    esac
+done
+shift $(($OPTIND-1))
+
+if [ -z $uname ]; then
+    read -rsep "NASA Earthdata username: " uname
+    echo ""
+fi
+
+if [ -z $passwd ]; then
+    read -rsep "NASA Earthdata password: " passwd
+    echo ""
+fi
+
+declare -a targets=(
+    "ancillary_data_doc_ECCO_V${v}r${r}.tar.gz"
+    "ancillary_data_input_init_ECCO_V${v}r${r}.tar.gz"
+    "ancillary_data_input_forcing_ECCO_V${v}r${r}.tar.gz"
+    "ancillary_data_native_grid_files_ECCO_V${v}r${r}.tar.gz"
+    "ancillary_data_data_constraints_ECCO_V${v}r${r}.tar.gz"
+    "ancillary_data_misc_ECCO_V${v}r${r}.tar.gz"
+)
+
+for target in ${targets[@]}; do
+    wget --user=${uname} --password=${passwd} ${rooturl}/${target}
+    echo "$(basename $0): extracting files from ${target} ..."
+    tar -xvf ${target}
+    echo "$(basename $0): ... done extracting files from ${target}."
+    if [ $keep = no ]; then
+        echo "$(basename $0): keep archive files (-k) option not selected; removing ${target}."
+        rm ${target}
+    fi
+done
+

--- a/ECCOv4 Release 4/scripts/eget
+++ b/ECCOv4 Release 4/scripts/eget
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# eget - download (get) ECCO and MITgcm source, configuration, and ancillary data
+#
+
+# configuration (perhaps cfg/ENV at some point):
+v=4; r=4
+mitgcmrepo=https://github.com/MITgcm/MITgcm.git
+eccorepo=https://github.com/ECCO-GROUP/ECCO-v${v}-Configurations.git
+branch=checkpoint66g
+
+usage() {
+    echo "$(basename $0) - download (get) ECCO V${v}r${r} and MITgcm source, configuration, and ancillary data"
+    echo "usage: $(basename $0) [-u username] [-p password] [-k] [dir]"
+    echo "where:"
+    echo "    -u    NASA Earthdata username (prompt if not provided)"
+    echo "    -p    NASA Earthdata password (prompt if not provided)"
+    echo "    -k    Keep downloaded tarfiles after extraction"
+    echo "    dir   Top-level working directory"
+    echo "note: $(basename $0)calls the eadd utility for ECCO ancillary data download"
+}
+version() { echo "1.0"; }
+
+nargs=1
+keep=no
+while getopts ":u:p:hkv" opt; do
+    case $opt in
+        k  ) keep=yes ;;
+        u  ) uname=$OPTARG ;;
+        p  ) passwd=$OPTARG ;;
+        h  ) usage
+             exit 1 ;;
+        v  ) version
+             exit 1 ;;
+        \? ) usage
+             exit 1 ;;
+    esac
+done
+shift $(($OPTIND-1))
+
+if [[ $# -ne $nargs ]]; then
+    usage
+    exit 1
+fi
+
+workingdir=$1
+
+if [ -z $uname ]; then
+    read -rsep "NASA Earthdata username: " uname
+    echo ""
+fi
+
+if [ -z $passwd ]; then
+    read -rsep "NASA Earthdata password: " passwd
+    echo ""
+fi
+
+if mkdir $workingdir && cd $workingdir; then
+
+    #
+    # clone MITgcm source:
+    #
+
+    echo "$(basename $0): cloning git repository $mitgcmrepo..."
+    git clone $mitgcmrepo -b $branch
+    echo "$(basename $0): ...done cloning $(basename $mitgcmrepo)."
+
+    #
+    # clone ecco configurations:
+    #
+
+    echo "$(basename $0): cloning ecco v${v}r${r} configurations, $eccorepo..."
+    git clone $eccorepo
+    mkdir -p ECCOV${v}/release${r}
+    cp -r "ECCO-v${v}-Configurations/ECCOv${v} Release ${r}/code" ECCOV${v}/release${r}/code
+    cp -r "ECCO-v${v}-Configurations/ECCOv${v} Release ${r}/namelist" ECCOV${v}/release${r}/namelist
+    echo "$(basename $0): ...done cloning $(basename $eccorepo)."
+
+    #
+    # download ecco ancillary data:
+    #
+
+    if cd ECCOV${v}/release${r} && mkdir input && cd input; then
+        if [ $keep = yes ]; then
+            eadd -u ${uname} -p ${passwd} -k
+        else
+            eadd -u ${uname} -p ${passwd}
+        fi
+    fi
+fi
+
+cd $cwd


### PR DESCRIPTION
…load (eadd)

eget (ECCO V4r4 "get") and eadd (ECCO "a"uxiliary "d"ata "d"ownload) automates the steps up through Section 4 in O. Wang and I. Fenty, "Instructions for reproducing ECCO Version 4 Release 4". eget, the top-level script, downloads the MITgcm source code (checkpoint66g repository), the ECCO-v4-Configurations repository, and calls eadd (which can also be called separately) to download all PO.DACC ancillary data files.