### PR TITLE
Fix a typo in data.ecco of flux-forced V4r4

### DIFF
--- a/ECCOv4 Release 4/flux-forced/namelist/data.ecco
+++ b/ECCOv4 Release 4/flux-forced/namelist/data.ecco
@@ -18,7 +18,7 @@
   gencost_avgperiod(1)  = 'month',
   gencost_barfile(1) = 'm_boxmean_eta_dyn',
   gencost_errfile(1) = 'mask_BeaufortSea.bin'
-  gencost_mask(1) = 'v4r3_maskCtrl'
+  gencost_mask(1) = 'v4_maskCtrl'
   gencost_name(1) = 'boxmean',
   gencost_timevaryweight(1)=.FALSE. 
   gencost_preproc(1,1)='skip',


### PR DESCRIPTION
Fix a typo in data.ecco of the flux-forced version of V4r4