### PR TITLE
Add data.ctrl having atmospheric controls

### DIFF
--- a/ECCOv4 Release 4/namelist/data.ctrl.unpack.inclatmctrl
+++ b/ECCOv4 Release 4/namelist/data.ctrl.unpack.inclatmctrl
@@ -1,0 +1,136 @@
+# *********************
+# ECCO controlvariables
+# *********************
+ &ctrl_nml
+#
+ doSinglePrecTapelev=.TRUE.,
+ ctrlSmoothCorrel2D=.TRUE.,
+ ctrlSmoothCorrel3D=.TRUE.,
+  ctrlUseGen=.TRUE.,
+#to start from given xx*00.data files
+# doinitxx = .FALSE.,
+# doMainUnpack = .FALSE.,
+#to start from given ecco_ctrl... files
+  doinitxx = .FALSE.,
+#
+#doPackDiag = .TRUE.,
+ forcingPrecond=1.,
+/
+
+#
+# *********************
+# names for ctrl_pack/unpack
+# *********************
+ &ctrl_packnames
+ /
+#
+# *********************
+# names for CTRL_GENARR, CTRL_GENTIM
+# *********************
+ &CTRL_NML_GENARR
+ xx_gentim2d_weight(1) = 'r2.watemp_var_tot.data',
+ xx_gentim2d_file(1)='xx_atemp',
+ xx_gentim2d_period(1)=1209600.0,
+ xx_gentim2d_preproc(1,1)='WC01',
+ xx_gentim2d_preproc_i(1,1)=1,
+ mult_gentim2d(1) = 1.,
+#
+ xx_gentim2d_weight(2) = 'r2.wprecip_var_nonseason_20150807.data',
+ xx_gentim2d_file(2)='xx_precip',
+ xx_gentim2d_period(2)=1209600.0,
+ xx_gentim2d_preproc(1,2)='WC01',
+ xx_gentim2d_preproc_i(1,2)=1,
+ mult_gentim2d(2) = 1.,
+#
+ xx_gentim2d_weight(3) = 'r2.wswdown_var_tot.data',
+ xx_gentim2d_file(3)='xx_swdown',
+ xx_gentim2d_period(3)=1209600.0,
+ xx_gentim2d_preproc(1,3)='WC01',
+ xx_gentim2d_preproc_i(1,3)=1,
+ mult_gentim2d(3) = 1.,
+#
+ xx_gentim2d_weight(4) = 'r2.wlwdown_var_tot.data',
+ xx_gentim2d_file(4)='xx_lwdown',
+ xx_gentim2d_period(4)=1209600.0,
+ xx_gentim2d_preproc(1,4)='WC01',
+ xx_gentim2d_preproc_i(1,4)=1,
+ mult_gentim2d(4) = 1.,
+#
+ xx_gentim2d_weight(5) = 'r2.waqh_var_tot.data',
+ xx_gentim2d_file(5)='xx_aqh',
+ xx_gentim2d_period(5)=1209600.0,
+ xx_gentim2d_preproc(1,5)='WC01',
+ xx_gentim2d_preproc_i(1,5)=1,
+ mult_gentim2d(5) = 1.,
+#
+ xx_gentim2d_weight(6) = 'r2.wtauu_var_tot.data',
+ xx_gentim2d_file(6)='xx_tauu',
+ xx_gentim2d_period(6)=1209600.0,
+ xx_gentim2d_preproc(1,6)='WC01',
+ xx_gentim2d_preproc_i(1,6)=1,
+ mult_gentim2d(6) = 1.,
+#
+ xx_gentim2d_weight(7) = 'r2.wtauv_var_tot.data',
+ xx_gentim2d_file(7)='xx_tauv',
+ xx_gentim2d_period(7)=1209600.0,
+ xx_gentim2d_preproc(1,7)='WC01',
+ xx_gentim2d_preproc_i(1,7)=1,
+ mult_gentim2d(7) = 1.,
+#
+ xx_genarr2d_weight(1) = 'SSH_weights_nonseasonal_rms_areascaled.bin',
+ xx_genarr2d_file(1)='xx_etan',
+ xx_genarr2d_bounds(1:5,1)=-9.0,-8.9,8.9,9.0,0.,
+ xx_genarr2d_preproc(1,1)='WC01',
+ xx_genarr2d_preproc_i(1,1)=1,
+ mult_genarr2d(1) = 1.,
+#
+ xx_genarr3d_weight(1) = 'Theta_weights_nonseasonal_rmsv2_areascaled.bin',
+ xx_genarr3d_file(1)='xx_theta',
+ xx_genarr3d_bounds(1:5,1)=-2.0,-1.9,39.,40.,0.,
+ xx_genarr3d_preproc(1,1)='WC01',
+ xx_genarr3d_preproc_i(1,1)=1,
+ mult_genarr3d(1) = 1.,
+#
+ xx_genarr3d_weight(2) = 'Salt_weights_nonseasonal_rmsv2_areascaled.bin',
+ xx_genarr3d_file(2)='xx_salt',
+ xx_genarr3d_bounds(1:5,2)=20.,20.5,40.5,41.,0.,
+ xx_genarr3d_preproc(1,2)='WC01',
+ xx_genarr3d_preproc_i(1,2)=1,
+ mult_genarr3d(2) = 1.,
+#
+ xx_genarr3d_weight(3) = 'r2.wkapgmFldv2.data',
+ xx_genarr3d_file(3)='xx_kapgm',
+ xx_genarr3d_bounds(1:5,3)=1.E2,2.E2,0.9E4,1.E4,0.,
+ xx_genarr3d_preproc(1,3)='WC01',
+ xx_genarr3d_preproc_i(1,3)=1,
+ mult_genarr3d(3) = 1.,
+#
+ xx_genarr3d_weight(4) = 'r2.wkaprediFldv2.data',
+ xx_genarr3d_file(4)='xx_kapredi',
+ xx_genarr3d_bounds(1:5,4)=1.E2,2.E2,0.9E4,1.E4,0.,
+ xx_genarr3d_preproc(1,4)='WC01',
+ xx_genarr3d_preproc_i(1,4)=1,
+ mult_genarr3d(4) = 1.,
+#
+ xx_genarr3d_weight(5) = 'r2.wdiffkrFldv2.data',
+ xx_genarr3d_file(5)='xx_diffkr',
+ xx_genarr3d_bounds(1:5,5)=1.E-6,2.E-6,4.E-4,5.E-4,0.,
+ xx_genarr3d_preproc(1,5)='WC01',
+ xx_genarr3d_preproc_i(1,5)=1,
+ mult_genarr3d(5) = 1.,
+#
+ xx_genarr3d_weight(6) = 'Uvel_weights_nonseasonal_rmsv2_areascaled.bin',
+ xx_genarr3d_file(6)='xx_uvel',
+ xx_genarr3d_bounds(1:5,6)=-3.,-2.9, 2.9,3.,0.,
+ xx_genarr3d_preproc(1,6)='WC01',
+ xx_genarr3d_preproc_i(1,6)=1,
+ mult_genarr3d(6) = 1.,
+#
+ xx_genarr3d_weight(7) = 'Vvel_weights_nonseasonal_rmsv2_areascaled.bin', 
+ xx_genarr3d_file(7)='xx_vvel',
+ xx_genarr3d_bounds(1:5,7)=-3.,-2.9, 2.9,3.,0.,
+ xx_genarr3d_preproc(1,7)='WC01',
+ xx_genarr3d_preproc_i(1,7)=1,
+ mult_genarr3d(7) = 1.,
+
+ /

--- a/ECCOv4 Release 4/namelist/data.ctrl_itXX.inclatmctrl
+++ b/ECCOv4 Release 4/namelist/data.ctrl_itXX.inclatmctrl
@@ -1,0 +1,136 @@
+# *********************
+# ECCO controlvariables
+# *********************
+ &ctrl_nml
+#
+ doSinglePrecTapelev=.TRUE.,
+ ctrlSmoothCorrel2D=.TRUE.,
+ ctrlSmoothCorrel3D=.TRUE.,
+  ctrlUseGen=.TRUE.,
+#to start from given xx*00.data files
+  doinitxx = .FALSE.,
+  doMainUnpack = .FALSE.,
+#to start from given ecco_ctrl... files
+# doinitxx = .FALSE.,
+#
+#doPackDiag = .TRUE.,
+ forcingPrecond=1.,
+/
+
+#
+# *********************
+# names for ctrl_pack/unpack
+# *********************
+ &ctrl_packnames
+ /
+#
+# *********************
+# names for CTRL_GENARR, CTRL_GENTIM
+# *********************
+ &CTRL_NML_GENARR
+ xx_gentim2d_weight(1) = 'r2.watemp_var_tot.data',
+ xx_gentim2d_file(1)='xx_atemp',
+ xx_gentim2d_period(1)=1209600.0,
+ xx_gentim2d_preproc(1,1)='WC01',
+ xx_gentim2d_preproc_i(1,1)=1,
+ mult_gentim2d(1) = 1.,
+#
+ xx_gentim2d_weight(2) = 'r2.wprecip_var_nonseason_20150807.data',
+ xx_gentim2d_file(2)='xx_precip',
+ xx_gentim2d_period(2)=1209600.0,
+ xx_gentim2d_preproc(1,2)='WC01',
+ xx_gentim2d_preproc_i(1,2)=1,
+ mult_gentim2d(2) = 1.,
+#
+ xx_gentim2d_weight(3) = 'r2.wswdown_var_tot.data',
+ xx_gentim2d_file(3)='xx_swdown',
+ xx_gentim2d_period(3)=1209600.0,
+ xx_gentim2d_preproc(1,3)='WC01',
+ xx_gentim2d_preproc_i(1,3)=1,
+ mult_gentim2d(3) = 1.,
+#
+ xx_gentim2d_weight(4) = 'r2.wlwdown_var_tot.data',
+ xx_gentim2d_file(4)='xx_lwdown',
+ xx_gentim2d_period(4)=1209600.0,
+ xx_gentim2d_preproc(1,4)='WC01',
+ xx_gentim2d_preproc_i(1,4)=1,
+ mult_gentim2d(4) = 1.,
+#
+ xx_gentim2d_weight(5) = 'r2.waqh_var_tot.data',
+ xx_gentim2d_file(5)='xx_aqh',
+ xx_gentim2d_period(5)=1209600.0,
+ xx_gentim2d_preproc(1,5)='WC01',
+ xx_gentim2d_preproc_i(1,5)=1,
+ mult_gentim2d(5) = 1.,
+#
+ xx_gentim2d_weight(6) = 'r2.wtauu_var_tot.data',
+ xx_gentim2d_file(6)='xx_tauu',
+ xx_gentim2d_period(6)=1209600.0,
+ xx_gentim2d_preproc(1,6)='WC01',
+ xx_gentim2d_preproc_i(1,6)=1,
+ mult_gentim2d(6) = 1.,
+#
+ xx_gentim2d_weight(7) = 'r2.wtauv_var_tot.data',
+ xx_gentim2d_file(7)='xx_tauv',
+ xx_gentim2d_period(7)=1209600.0,
+ xx_gentim2d_preproc(1,7)='WC01',
+ xx_gentim2d_preproc_i(1,7)=1,
+ mult_gentim2d(7) = 1.,
+#
+ xx_genarr2d_weight(1) = 'SSH_weights_nonseasonal_rms_areascaled.bin',
+ xx_genarr2d_file(1)='xx_etan',
+ xx_genarr2d_bounds(1:5,1)=-9.0,-8.9,8.9,9.0,0.,
+ xx_genarr2d_preproc(1,1)='WC01',
+ xx_genarr2d_preproc_i(1,1)=1,
+ mult_genarr2d(1) = 1.,
+#
+ xx_genarr3d_weight(1) = 'Theta_weights_nonseasonal_rmsv2_areascaled.bin',
+ xx_genarr3d_file(1)='xx_theta',
+ xx_genarr3d_bounds(1:5,1)=-2.0,-1.9,39.,40.,0.,
+ xx_genarr3d_preproc(1,1)='WC01',
+ xx_genarr3d_preproc_i(1,1)=1,
+ mult_genarr3d(1) = 1.,
+#
+ xx_genarr3d_weight(2) = 'Salt_weights_nonseasonal_rmsv2_areascaled.bin',
+ xx_genarr3d_file(2)='xx_salt',
+ xx_genarr3d_bounds(1:5,2)=20.,20.5,40.5,41.,0.,
+ xx_genarr3d_preproc(1,2)='WC01',
+ xx_genarr3d_preproc_i(1,2)=1,
+ mult_genarr3d(2) = 1.,
+#
+ xx_genarr3d_weight(3) = 'r2.wkapgmFldv2.data',
+ xx_genarr3d_file(3)='xx_kapgm',
+ xx_genarr3d_bounds(1:5,3)=1.E2,2.E2,0.9E4,1.E4,0.,
+ xx_genarr3d_preproc(1,3)='WC01',
+ xx_genarr3d_preproc_i(1,3)=1,
+ mult_genarr3d(3) = 1.,
+#
+ xx_genarr3d_weight(4) = 'r2.wkaprediFldv2.data',
+ xx_genarr3d_file(4)='xx_kapredi',
+ xx_genarr3d_bounds(1:5,4)=1.E2,2.E2,0.9E4,1.E4,0.,
+ xx_genarr3d_preproc(1,4)='WC01',
+ xx_genarr3d_preproc_i(1,4)=1,
+ mult_genarr3d(4) = 1.,
+#
+ xx_genarr3d_weight(5) = 'r2.wdiffkrFldv2.data',
+ xx_genarr3d_file(5)='xx_diffkr',
+ xx_genarr3d_bounds(1:5,5)=1.E-6,2.E-6,4.E-4,5.E-4,0.,
+ xx_genarr3d_preproc(1,5)='WC01',
+ xx_genarr3d_preproc_i(1,5)=1,
+ mult_genarr3d(5) = 1.,
+#
+ xx_genarr3d_weight(6) = 'Uvel_weights_nonseasonal_rmsv2_areascaled.bin',
+ xx_genarr3d_file(6)='xx_uvel',
+ xx_genarr3d_bounds(1:5,6)=-3.,-2.9, 2.9,3.,0.,
+ xx_genarr3d_preproc(1,6)='WC01',
+ xx_genarr3d_preproc_i(1,6)=1,
+ mult_genarr3d(6) = 1.,
+#
+ xx_genarr3d_weight(7) = 'Vvel_weights_nonseasonal_rmsv2_areascaled.bin', 
+ xx_genarr3d_file(7)='xx_vvel',
+ xx_genarr3d_bounds(1:5,7)=-3.,-2.9, 2.9,3.,0.,
+ xx_genarr3d_preproc(1,7)='WC01',
+ xx_genarr3d_preproc_i(1,7)=1,
+ mult_genarr3d(7) = 1.,
+
+ /


### PR DESCRIPTION
Add example data.ctrl files that include atmospheric controls:
data.ctrl.unpack.inclatmctrl for starting from ecco_ctrl file 
data.ctrl_itXX.inclatmctrl for starting from xx files 
To use either file, one needs to copy the file to data.ctrl. 