### PR TITLE
Initialize offline tracer using a pickup file

### DIFF
--- a/ECCOv4 Release 4/flux-forced/doc/README_offline_ptracer.md
+++ b/ECCOv4 Release 4/flux-forced/doc/README_offline_ptracer.md
@@ -17,7 +17,7 @@ Compiling and running offline passive tracer is similar to that for the flux-for
 - Run
   - Use ``namelist_offline_ptracer`` instead of ``namelist`` for input name list files
   - ECCO V4r4's 7-day mean circulation and mixing parameters are available at https://ecco.jpl.nasa.gov/drive/files/Version4/Release4/other/flux-forced/state_weekly. The fields are organized by variable (subdirectory). Download ``state_weekly`` inclduing all subdirectories (and keep the directory structure the same) to your local machine. When running the model, make them accessible to a run by linking all variables into your run directory.  
-  - Initializing tracer by creating a single-precision, 3d file on the model grid. Specify whatever tracer value one wants to the region one wants to release tracer and zero elsewhere. Create a link to this file with the name "theta_init_V4r4.bin" in the run directory.
+  - Initializing tracer by creating a double-precision, 3d file on the model grid. Specify whatever tracer value one wants to the region one wants to release tracer and zero elsewhere. Name the file as pickup_ptracers.ZZZZZZZZZZ.data, where "ZZZZZZZZZZ" is a 10-digit nunber for Iter0 (as specified in the namelist file "data"), left padded with zeros. For example, if nIter0 is 1, then the filename is pickup_ptracers.0000000001.data. Copy or create a link to this file in the run directory.
   - Monthly mean (ptracer_mon_mean) and snapshot (ptracer_mon_mean) of tracer distribution are output to diags/ by the MITgcm diagnostics package. 
   - Because there is no time stepping for model state, forcing files for the flux-forced V4r4 are *not* needed for running offline passive tracer.
        

--- a/ECCOv4 Release 4/flux-forced/namelist_offline_ptracer/data.ptracers
+++ b/ECCOv4 Release 4/flux-forced/namelist_offline_ptracer/data.ptracers
@@ -13,7 +13,7 @@
  PTRACERS_ref(1,1)=0.,
 #PTRACERS_useGMRedi(1)=.FALSE. ,
  PTRACERS_names(1)='trace_theta',
- PTRACERS_initialFile(1)='theta_init_V4r4.bin',
+#PTRACERS_initialFile(1)='theta_init_V4r4.bin',
  PTRACERS_ImplVertAdv(1)=.TRUE.
 #
 #PTRACERS_ref(1,2)=1.,


### PR DESCRIPTION
Initialize offline tracer using a pickup file instead of specifying PTRACERS_initialFile in data.ptracers. See ECCO-v4-Configurations/ECCOv4 Release 4/flux-forced/doc/README_offline_ptracer.md for details. Using a pickup file is more flexible than specifying PTRACERS_initialFile in data.ptracers. 
