### PR TITLE
Allow rename_offline_adj_diags_fn.sh to take YES as an argument

### DIFF
--- a/ECCOv4 Release 4/flux-forced/scripts/rename_offline_adj_diags_fn.sh
+++ b/ECCOv4 Release 4/flux-forced/scripts/rename_offline_adj_diags_fn.sh
@@ -16,9 +16,12 @@ show_help() {
     echo "Arguments:"
     echo "  DIRECTORY    Optional. The directory containing files to rename (default is current directory)."
     echo "  NUMBER       Optional. The number to subtract from (default is 227639 [=nTimeSteps+1])."
+    echo "  CONFIRMATION Optional. Specify 'YES' to skip confirmation prompt."
     echo
     echo "Example:"
-    echo "  $(basename $0) /path/to/directory"
+    echo "  $(basename $0)" 
+    echo "or"
+    echo "  $(basename $0) /path/to/directory 227639 YES"
     exit 1
 }
 
@@ -26,6 +29,7 @@ show_help() {
 # DEFAULT_NUMBER is set to nTimeSteps+1
 DEFAULT_NUMBER=227639
 DEFAULT_DIRECTORY=$(pwd)
+SKIP_CONFIRMATION=false
 
 # Check for help option
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
@@ -43,6 +47,9 @@ if [ "$#" -ge 1 ]; then
     elif [[ $1 =~ ^[0-9]+$ ]]; then
         NUMBER=$1
         shift
+    elif [[ "$1" == "YES" ]]; then
+        SKIP_CONFIRMATION=true
+        shift
     else
         echo "Invalid argument: $1"
         show_help
@@ -52,28 +59,48 @@ fi
 if [ "$#" -ge 1 ]; then
     if [[ $1 =~ ^[0-9]+$ ]]; then
         NUMBER=$1
+        shift
+    elif [[ "$1" == "YES" ]]; then
+        SKIP_CONFIRMATION=true
+        shift
     else
-        echo "Invalid number: $1"
+        echo "Invalid argument: $1"
         show_help
     fi
 fi
 
+if [ "$#" -ge 1 ]; then
+    if [[ "$1" == "YES" ]]; then
+        SKIP_CONFIRMATION=true
+        shift
+    else
+        echo "Invalid argument: $1"
+        show_help
+    fi
+fi
+
+
 # Function to ask for user confirmation
 confirm_action() {
-    echo "You are about to rename files in the following directory: $DIRECTORY"
-    echo "This will affect files where the last 15 characters are a 10-digit number followed by '.data' or '.meta'."
-    echo "The renaming process will subtract each number from $NUMBER."
-    echo "The renamed files will be first placed in a temporary subdirectory named 'offline_adj_file_renamed_dir',"
-    echo "and then they wll be moved back to the same directory as the input files."
-    read -p "Are you sure you want to proceed? Type 'YES' to confirm: " confirmation
-    if [ "$confirmation" != "YES" ]; then
-        echo "Operation cancelled by user."
-        exit 1
+    if [ "$SKIP_CONFIRMATION" == false ]; then
+        echo "You are about to rename files in the following directory: $DIRECTORY"
+        echo "This will affect files where the last 15 characters are a 10-digit number followed by '.data' or '.meta'."
+        echo "The renaming process will subtract each number from $NUMBER."
+        echo "The renamed files will be first placed in a temporary subdirectory named 'offline_adj_file_renamed_dir',"
+        echo "and then they wll be moved back to the same directory as the input files."
+        read -p "Are you sure you want to proceed? Type 'YES' to confirm: " confirmation
+        if [ "$confirmation" != "YES" ]; then
+            echo "Operation cancelled by user."
+            exit 1
+        fi
     fi
 }
 
 # Ask for user confirmation
 confirm_action
+
+# Counter for the number of files renamed
+renamed_files_count=0
 
 # Create a subdirectory for the renamed files if it doesn't exist
 RENAME_DIR="$DIRECTORY/offline_adj_file_renamed_dir"
@@ -86,7 +113,7 @@ fi
 mkdir -p "$RENAME_DIR"
 
 # Loop through files ending with ".data" or ".meta"
-for file in "$DIRECTORY"/*.{data,meta}
+for file in "$DIRECTORY"/"ptracer"*.{data,meta}
 do
     # Check if the file matches the pattern (last 15 characters)
     if [[ $file =~ ([0-9]{10})\.(data|meta)$ ]]
@@ -125,10 +152,18 @@ do
         
         # Move the renamed file back to the input directory
         mv "$new_file" ${DIRECTORY}/
+
+        # Increment the renamed files counter
+        ((renamed_files_count++))
     fi
 done
 
 # Remove the temporary directory
 rmdir ${RENAME_DIR}
 
-echo "Done"
+# Check if any files were renamed and print the appropriate message
+if [ "$renamed_files_count" -gt 0 ]; then
+    echo "$renamed_files_count files were renamed."
+else
+    echo "No files were renamed."
+fi


### PR DESCRIPTION
When 'YES' is provided as an argument, rename_offline_adj_diags_fn.sh skips the step of asking the user to type in 'YES' for confirmation.

Also, add feature to count and display the number of files named.