### PR TITLE
Allow model to restart from pickups

### DIFF
--- a/ECCOv4 Release 4/flux-forced/code/code_ad_diff.list
+++ b/ECCOv4 Release 4/flux-forced/code/code_ad_diff.list
@@ -1,0 +1,2 @@
+ecco_read_pickup.f
+ecco_write_pickup.f

--- a/ECCOv4 Release 4/flux-forced/code/ctrl_cost_gen.F
+++ b/ECCOv4 Release 4/flux-forced/code/ctrl_cost_gen.F
@@ -1,0 +1,554 @@
+C $Header: /u/gcmpack/MITgcm/pkg/ctrl/ctrl_cost_gen.F,v 1.9 2015/10/29 03:43:59 gforget Exp $
+C $Name:  $
+
+c ----------------------------------------------------------------
+c --- ctrl_cost_gen2d
+c --- ctrl_cost_gen3d
+c ----------------------------------------------------------------
+
+c ----------------------------------------------------------------
+
+#include "CTRL_OPTIONS.h"
+#ifdef ALLOW_ECCO
+# include "ECCO_OPTIONS.h"
+#endif
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
+C     !ROUTINE: ctrl_cost_gen2d
+C     !INTERFACE:
+      subroutine ctrl_cost_gen2d(
+     I                       startrec,
+     I                       endrec,
+     I                       xx_gen_file,
+     I                       xx_gen_dummy,
+     I                       xx_gen_period,
+     I                       xx_gen_weight,
+     I                       dodimensionalcost,
+     O                       num_gen_anom,
+     O                       objf_gen_anom,
+#ifdef ECCO_CTRL_DEPRECATED
+     I                       xx_gen_wmean,
+     O                       num_gen_mean,
+     O                       objf_gen_mean,
+     O                       objf_gen_smoo,
+     I                       xx_gen_remo_intercept,
+     I                       xx_gen_remo_slope,
+#endif /* ECCO_CTRL_DEPRECATED */
+     I                       xx_gen_mask,
+     I                       myThid
+     &                         )
+
+C     !DESCRIPTION: \bv
+C     Generic routine for all 2D control penalty terms
+C     \ev
+
+      implicit none
+
+c     == global variables ==
+
+#include "EEPARAMS.h"
+#include "SIZE.h"
+#include "PARAMS.h"
+#include "GRID.h"
+
+#ifdef ALLOW_ECCO
+#  include "ecco.h"
+#endif
+#ifdef ALLOW_CTRL
+# include "ctrl.h"
+# include "optim.h"
+#endif
+
+c     == routine arguments ==
+
+      integer startrec
+      integer endrec
+      character*(MAX_LEN_FNAM) xx_gen_file
+      _RL xx_gen_dummy
+      _RL xx_gen_period
+      _RL xx_gen_weight(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      logical dodimensionalcost
+      _RL num_gen_anom(nsx,nsy)
+      _RL objf_gen_anom(nsx,nsy)
+#ifdef ECCO_CTRL_DEPRECATED
+      _RL xx_gen_wmean
+      _RL num_gen_mean(nsx,nsy)
+      _RL num_gen_smoo(nsx,nsy)
+      _RL objf_gen_mean(nsx,nsy)
+      _RL objf_gen_smoo(nsx,nsy)
+      _RL xx_gen_remo_intercept
+      _RL xx_gen_remo_slope
+#endif /* ECCO_CTRL_DEPRECATED */
+      _RS xx_gen_mask(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
+      integer myThid
+
+#ifdef ALLOW_CTRL
+
+c     == local variables ==
+
+      integer bi,bj
+      integer i,j,kk
+      integer itlo,ithi
+      integer jtlo,jthi
+      integer jmin,jmax
+      integer imin,imax
+      integer nrec
+      integer irec
+      integer lrec
+      integer ilfld
+
+      _RL fctile
+      _RL fctilem
+      _RL tmpx
+      _RL lengthscale
+
+#ifdef ECCO_CTRL_DEPRECATED
+      _RL xx_mean(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+#endif /* ECCO_CTRL_DEPRECATED */
+
+      logical doglobalread
+      logical ladinit
+
+      character*(80) fnamefld
+
+c     == external functions ==
+
+      integer  ilnblnk
+      external ilnblnk
+
+CEOP
+
+      jtlo = mybylo(myThid)
+      jthi = mybyhi(myThid)
+      itlo = mybxlo(myThid)
+      ithi = mybxhi(myThid)
+      jmin = 1
+      jmax = sny
+      imin = 1
+      imax = snx
+
+      lengthscale = 1. _d 0
+
+c--   Read state record from global file.
+      doglobalread = .false.
+      ladinit      = .false.
+
+c     Number of records to be used.
+      nrec = endrec-startrec+1
+
+      if (optimcycle .ge. 0) then
+        ilfld=ilnblnk( xx_gen_file )
+        write(fnamefld(1:80),'(2a,i10.10)')
+     &       xx_gen_file(1:ilfld),'.',optimcycle
+      endif
+
+c--   >>> Loop 1 to compute mean forcing:
+      do bj = jtlo,jthi
+        do bi = itlo,ithi
+          num_gen_anom(bi,bj)  = 0. _d 0
+          objf_gen_anom(bi,bj) = 0. _d 0
+#ifdef ECCO_CTRL_DEPRECATED
+          do j = jmin,jmax
+            do i = imin,imax
+              xx_mean(i,j,bi,bj)   = 0. _d 0
+            enddo
+          enddo
+          num_gen_mean(bi,bj)  = 0. _d 0
+          num_gen_smoo(bi,bj)  = 0. _d 0
+          objf_gen_mean(bi,bj) = 0. _d 0
+          objf_gen_smoo(bi,bj) = 0. _d 0
+#endif /* ECCO_CTRL_DEPRECATED */
+        enddo
+      enddo
+
+#ifndef ECCO_CTRL_DEPRECATED
+c--   >>> Loop over records.
+catn: this is the cost of xx_*.00 , so it needs to loop
+catn over the same records startrec:endrec and not 1:Nrec
+      do irec = 1,nrec
+        lrec=startrec+irec-1
+
+#ifdef ALLOW_AUTODIFF
+        call active_read_xy(
+     &        fnamefld, tmpfld2d, lrec, doglobalread,
+     &        ladinit, optimcycle, myThid, xx_gen_dummy )
+#else
+        CALL READ_REC_XY_RL( fnamefld, tmpfld2d, lrec, 1, myThid )
+#endif
+
+c--     Loop over this thread tiles.
+        do bj = jtlo,jthi
+          do bi = itlo,ithi
+
+c--         Determine the weights to be used.
+            kk = 1
+            fctile = 0. _d 0
+            do j = jmin,jmax
+              do i = imin,imax
+                if (xx_gen_mask(i,j,kk,bi,bj) .ne. 0. _d 0) then
+
+                tmpx = tmpfld2d(i,j,bi,bj)
+                IF ( dodimensionalcost ) THEN
+                  fctile = fctile + xx_gen_weight(i,j,bi,bj)*tmpx*tmpx
+                ELSE
+                  fctile = fctile + tmpx*tmpx
+                ENDIF
+                if ( xx_gen_weight(i,j,bi,bj) .ne. 0. _d 0 )
+     &            num_gen_anom(bi,bj) = num_gen_anom(bi,bj)
+     &            + 1. _d 0
+                endif
+
+              enddo
+            enddo
+
+            objf_gen_anom(bi,bj) = objf_gen_anom(bi,bj) + fctile
+
+          enddo
+        enddo
+
+c--   End of loop over records.
+      enddo
+
+#else /* ECCO_CTRL_DEPRECATED */
+
+      IF ( dodimensionalcost ) THEN
+      do irec = 1,nrec
+
+#ifdef ALLOW_AUTODIFF
+        call active_read_xy(
+     &        fnamefld, tmpfld2d, irec, doglobalread,
+     &        ladinit, optimcycle, myThid, xx_gen_dummy )
+#else
+        CALL READ_REC_XY_RL( fnamefld, tmpfld2d, iRec, 1, myThid )
+#endif
+
+c--     Loop over this thread tiles.
+        do bj = jtlo,jthi
+          do bi = itlo,ithi
+            do j = jmin,jmax
+              do i = imin,imax
+                xx_mean(i,j,bi,bj) = xx_mean(i,j,bi,bj)
+     &                + tmpfld2d(i,j,bi,bj)
+     &                - ( xx_gen_remo_intercept +
+     &                    xx_gen_remo_slope*(irec-1)*xx_gen_period )
+              enddo
+            enddo
+          enddo
+        enddo
+
+      enddo
+
+      if ( xx_gen_wmean .NE. 0. ) then
+       do bj = jtlo,jthi
+        do bi = itlo,ithi
+c--     Determine the weights to be used.
+        kk = 1
+        fctilem = 0. _d 0
+        do j = jmin,jmax
+          do i = imin,imax
+            xx_mean(i,j,bi,bj)
+     &            = xx_mean(i,j,bi,bj)/float(nrec)
+            tmpx = xx_mean(i,j,bi,bj)/xx_gen_wmean
+            if (xx_gen_mask(i,j,kk,bi,bj) .ne. 0. _d 0) then
+#ifdef ALLOW_ECCO
+              if ( ABS(R_low(i,j,bi,bj)) .LT. 100.  _d 0)
+     &              tmpx = tmpx*ABS(R_low(i,j,bi,bj))/100.  _d 0
+              fctilem = fctilem + cosphi(i,j,bi,bj)*tmpx*tmpx
+              if ( cosphi(i,j,bi,bj) .ne. 0. _d 0)
+     &             num_gen_mean(bi,bj) = num_gen_mean(bi,bj) + 1. _d 0
+#else
+              fctilem = fctilem + tmpx*tmpx
+                   num_gen_mean(bi,bj) = num_gen_mean(bi,bj) + 1. _d 0
+#endif
+            endif
+          enddo
+        enddo
+        objf_gen_mean(bi,bj) = objf_gen_mean(bi,bj) + fctilem
+        enddo
+       enddo
+      endif
+      ENDIF !IF ( dodimensionalcost ) THEN
+
+c--   >>> Loop 2 over records.
+      do irec = 1,nrec
+
+#ifdef ALLOW_AUTODIFF
+        call active_read_xy(
+     &        fnamefld, tmpfld2d, irec, doglobalread,
+     &        ladinit, optimcycle, myThid, xx_gen_dummy )
+#else
+        CALL READ_REC_XY_RL( fnamefld, tmpfld2d, iRec, 1, myThid )
+#endif
+
+c--     Loop over this thread tiles.
+        do bj = jtlo,jthi
+          do bi = itlo,ithi
+
+c--         Determine the weights to be used.
+            kk = 1
+            fctile = 0. _d 0
+            do j = jmin,jmax
+              do i = imin,imax
+                if (xx_gen_mask(i,j,kk,bi,bj) .ne. 0. _d 0) then
+
+                IF ( dodimensionalcost ) THEN
+                  tmpx = tmpfld2d(i,j,bi,bj)
+     &                   - xx_mean(i,j,bi,bj)
+     &                   - ( xx_gen_remo_intercept +
+     &                       xx_gen_remo_slope*(irec-1)*xx_gen_period )
+#ifdef ALLOW_ECCO
+                  if ( ABS(R_low(i,j,bi,bj)) .LT. 100. _d 0 )
+     &              tmpx = tmpx*ABS(R_low(i,j,bi,bj))/100. _d 0
+                  fctile = fctile + xx_gen_weight(i,j,bi,bj)*tmpx*tmpx
+     &                   * cosphi(i,j,bi,bj)
+#else
+                  fctile = fctile + xx_gen_weight(i,j,bi,bj)*tmpx*tmpx
+#endif
+                ELSE !IF ( dodimensionalcost ) THEN
+                  tmpx = tmpfld2d(i,j,bi,bj)
+                  fctile = fctile + tmpx*tmpx
+                ENDIF !IF ( dodimensionalcost ) THEN
+#ifdef ALLOW_ECCO
+                  if ( xx_gen_weight(i,j,bi,bj)
+     &                *cosphi(i,j,bi,bj) .ne. 0. _d 0 )
+#else
+                  if ( xx_gen_weight(i,j,bi,bj) .ne. 0. _d 0 )
+#endif
+     &                 num_gen_anom(bi,bj) = num_gen_anom(bi,bj)
+     &                 + 1. _d 0
+
+                endif
+
+              enddo
+            enddo
+
+            objf_gen_anom(bi,bj) = objf_gen_anom(bi,bj) + fctile
+
+          enddo
+        enddo
+
+c--   End of loop over records.
+      enddo
+
+      IF ( dodimensionalcost ) THEN
+#ifdef ALLOW_SMOOTH_BC_COST_CONTRIBUTION
+
+c--   >>> Loop 2 over records.
+      do irec = 1,nrec
+
+#ifdef ALLOW_AUTODIFF
+        call active_read_xy(
+     &        fnamefld, tmpfld2d, irec, doglobalread,
+     &        ladinit, optimcycle, myThid, xx_gen_dummy )
+#else
+        CALL READ_REC_XY_RL( fnamefld, tmpfld2d, iRec, 1, myThid )
+#endif
+
+        _EXCH_XY_RL(tmpfld2d, myThid)
+
+c--     Loop over this thread tiles.
+        do bj = jtlo,jthi
+          do bi = itlo,ithi
+
+c--         Determine the weights to be used.
+            kk = 1
+            fctile = 0. _d 0
+            do j = jmin,jmax
+              do i = imin,imax
+                if (xx_gen_mask(i,j,kk,bi,bj) .ne. 0. _d 0) then
+                  tmpx =
+     &                 ( tmpfld2d(i+2,j,bi,bj)-tmpfld2d(i+1,j,bi,bj) )
+     &                   *maskW(i+1,j,kk,bi,bj)*maskW(i+2,j,kk,bi,bj)
+     &               + ( tmpfld2d(i+1,j,bi,bj)-tmpfld2d(i,j,bi,bj) )
+     &                   *maskW(i+1,j,kk,bi,bj)
+     &               + ( tmpfld2d(i,j+2,bi,bj)-tmpfld2d(i,j+1,bi,bj) )
+     &                   *maskS(i,j+1,kk,bi,bj)*maskS(i,j+2,kk,bi,bj)
+     &               + ( tmpfld2d(i,j+1,bi,bj)-tmpfld2d(i,j,bi,bj) )
+     &                   *maskS(i,j+1,kk,bi,bj)
+#ifdef ALLOW_ECCO
+                  if ( ABS(R_low(i,j,bi,bj)) .LT. 100. _d 0 )
+     &              tmpx = tmpx*ABS(R_low(i,j,bi,bj))/100. _d 0
+                  fctile = fctile
+     &               + xx_gen_weight(i,j,bi,bj)*cosphi(i,j,bi,bj)
+#else
+                  fctile = fctile
+     &               + xx_gen_weight(i,j,bi,bj)
+#endif
+     *                 *0.0161 _d 0*lengthscale/4.0 _d 0
+     &                 *tmpx*tmpx
+#ifdef ALLOW_ECCO
+                  if ( xx_gen_weight(i,j,bi,bj)*cosphi(i,j,bi,bj)
+     &                 .ne. 0.  _d 0 )
+#else
+                  if ( xx_gen_weight(i,j,bi,bj) .ne. 0. _d 0 )
+#endif
+     &                 num_gen_smoo(bi,bj) = num_gen_smoo(bi,bj)
+     &                 + 1. _d 0
+                endif
+              enddo
+            enddo
+
+            objf_gen_smoo(bi,bj) = objf_gen_smoo(bi,bj) + fctile
+
+          enddo
+        enddo
+
+c--   End of loop over records.
+      enddo
+
+#endif /* ALLOW_SMOOTH_BC_COST_CONTRIBUTION */
+      ENDIF !IF ( dodimensionalcost ) THEN
+
+#endif /* ECCO_CTRL_DEPRECATED */
+
+#endif /* ALLOW_CTRL */
+
+      return
+      end
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+CBOP
+C     !ROUTINE: ctrl_cost_gen3d
+C     !INTERFACE:
+      subroutine ctrl_cost_gen3d(
+     I                       xx_gen_file,
+     I                       xx_gen_dummy,
+     I                       xx_gen_weight,
+     I                       dodimensionalcost,
+     O                       num_gen,
+     O                       objf_gen,
+     I                       xx_gen_mask,
+     I                       myThid
+     &                         )
+
+C     !DESCRIPTION: \bv
+C     Generic routine for all 3D control penalty terms
+C     \ev
+
+      implicit none
+
+c     == global variables ==
+
+#include "EEPARAMS.h"
+#include "SIZE.h"
+#include "PARAMS.h"
+#include "GRID.h"
+
+#ifdef ALLOW_ECCO
+#  include "ecco.h"
+#endif
+#ifdef ALLOW_CTRL
+# include "ctrl.h"
+# include "optim.h"
+#endif
+
+c     == routine arguments ==
+
+      character*(MAX_LEN_FNAM) xx_gen_file
+      _RL xx_gen_dummy
+      _RL xx_gen_weight(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
+      logical dodimensionalcost
+      _RL num_gen(nsx,nsy)
+      _RL objf_gen(nsx,nsy)
+      _RS xx_gen_mask(1-olx:snx+olx,1-oly:sny+oly,nr,nsx,nsy)
+      INTEGER myThid
+
+#ifdef ALLOW_CTRL
+
+c     == local variables ==
+
+      integer bi,bj
+      integer i,j,k
+      integer itlo,ithi
+      integer jtlo,jthi
+      integer jmin,jmax
+      integer imin,imax
+      integer irec
+      integer ilfld
+
+      _RL tmpx
+
+      logical doglobalread
+      logical ladinit
+
+      character*(80) fnamefld
+
+c     == external functions ==
+
+      integer  ilnblnk
+      external ilnblnk
+
+CEOP
+
+      jtlo = mybylo(myThid)
+      jthi = mybyhi(myThid)
+      itlo = mybxlo(myThid)
+      ithi = mybxhi(myThid)
+      jmin = 1
+      jmax = sny
+      imin = 1
+      imax = snx
+
+c--   Read state record from global file.
+      doglobalread = .false.
+      ladinit      = .false.
+
+      if (optimcycle .ge. 0) then
+        ilfld = ilnblnk( xx_gen_file )
+        write(fnamefld(1:80),'(2a,i10.10)')
+     &       xx_gen_file(1:ilfld),'.',optimcycle
+      endif
+
+c--   >>> Loop 1 to compute mean forcing:
+      do bj = jtlo,jthi
+        do bi = itlo,ithi
+          num_gen(bi,bj)  = 0. _d 0
+          objf_gen(bi,bj) = 0. _d 0
+        enddo
+      enddo
+
+      irec = 1
+
+#ifdef ALLOW_AUTODIFF
+      call active_read_xyz( fnamefld, tmpfld3d, irec, doglobalread,
+     &                       ladinit, optimcycle, myThid
+     &        , xx_gen_dummy )
+#else
+        CALL READ_REC_XYZ_RL( fnamefld, tmpfld3d, iRec, 1, myThid )
+#endif
+
+c--     Loop over this thread tiles.
+        do bj = jtlo,jthi
+          do bi = itlo,ithi
+
+            num_gen(bi,bj)  = 0. _d 0
+            objf_gen(bi,bj) = 0. _d 0
+
+            do k = 1,nr
+            do j = jmin,jmax
+              do i = imin,imax
+                if (xx_gen_mask(i,j,k,bi,bj) .ne. 0. _d 0) then
+                  tmpx = tmpfld3d(i,j,k,bi,bj)
+                IF ( dodimensionalcost ) THEN
+                  objf_gen(bi,bj) = objf_gen(bi,bj)
+     &                 + xx_gen_weight(i,j,k,bi,bj)
+     &                 *tmpx*tmpx
+                ELSE
+                  objf_gen(bi,bj) = objf_gen(bi,bj) + tmpx*tmpx
+                ENDIF
+                if ( xx_gen_weight(i,j,k,bi,bj) .ne. 0. _d 0 )
+     &            num_gen(bi,bj) = num_gen(bi,bj) + 1. _d 0
+                endif
+              enddo
+            enddo
+            enddo
+
+          enddo
+        enddo
+
+#endif
+
+      return
+      end
+

--- a/ECCOv4 Release 4/flux-forced/code/ctrl_get_gen.F
+++ b/ECCOv4 Release 4/flux-forced/code/ctrl_get_gen.F
@@ -228,10 +228,20 @@ cph Initial wind stress adjustments are too vigorous.
 #endif
 
       if ( gencount0 .LE. 2 .AND.
+     &     nIter0 .LE. 1 .AND.
      &     ( xx_gen_file(1:7) .EQ. xx_tauu_file .OR.
      &       xx_gen_file(1:7) .EQ. xx_tauv_file ) .AND.
      &     ( xx_genperiod .NE. 0 ) ) then
          doCtrlUpdate = .FALSE.
+c--   Check if nIter0 is large enough
+       if ( nIter0 .GT. 1 .AND. 
+     &    nIter0 .LE. INT(2*(xx_genperiod+1. _d -5)/deltaTClock) ) then
+          print*,' When restarting the model (nIter0>1), '
+          print*,' nIter0 must be large enough: ',  nIter0
+          print*,' More complicated handling for small nIter0 is not'
+          print*,' implemented.'
+          stop   ' ... stopped in ctrl_get_gen.F.'
+       endif
       else
          doCtrlUpdate = .TRUE.
       endif

--- a/ECCOv4 Release 4/flux-forced/code/ctrl_init.F
+++ b/ECCOv4 Release 4/flux-forced/code/ctrl_init.F
@@ -1,0 +1,986 @@
+C $Header: /u/gcmpack/MITgcm/pkg/ctrl/ctrl_init.F,v 1.69 2015/12/25 15:24:51 gforget Exp $
+C $Name:  $
+
+#include "CTRL_OPTIONS.h"
+#ifdef ALLOW_EXF
+# include "EXF_OPTIONS.h"
+#endif
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+
+      subroutine ctrl_init( myThid )
+
+c     ==================================================================
+c     SUBROUTINE ctrl_init
+c     ==================================================================
+c
+c     o The vector of control variables is defined here.
+c
+c     ==================================================================
+c     SUBROUTINE ctrl_init
+c     ==================================================================
+
+      implicit none
+
+c     == global variables ==
+
+#include "EEPARAMS.h"
+#include "SIZE.h"
+#include "PARAMS.h"
+#include "GRID.h"
+#ifdef ALLOW_CTRL
+# include "CTRL_SIZE.h"
+# include "ctrl.h"
+# include "CTRL_GENARR.h"
+# include "CTRL_OBCS.h"
+# include "optim.h"
+#endif
+#ifdef ALLOW_CAL
+# include "cal.h"
+#endif
+#ifdef ALLOW_EXF
+# include "EXF_PARAM.h"
+#endif
+#ifdef ALLOW_DIC_CONTROL
+# include "DIC_CTRL.h"
+#endif
+
+c     == routine arguments ==
+
+      integer myThid
+
+c     == local variables ==
+
+      integer bi,bj
+      integer i,j,k
+      integer itlo,ithi
+      integer jtlo,jthi
+      integer jmin,jmax
+      integer imin,imax
+
+      integer ivar
+      integer startrec
+      integer endrec
+      integer diffrec
+      integer iarr
+
+      _RL dummy
+      _RL loctmp3d (1-olx:snx+olx,1-oly:sny+oly,Nr,nsx,nsy)
+
+#ifdef ALLOW_OBCS_CONTROL_MODES
+      INTEGER  length_of_rec,dUnit
+      INTEGER  MDS_RECLEN
+      EXTERNAL MDS_RECLEN
+#endif
+
+#ifdef ALLOW_GENTIM2D_CONTROL
+      CHARACTER*(MAX_LEN_FNAM) fnamegen
+      INTEGER ilgen, k2, diffrecFull, endrecFull
+#endif
+
+c     == external ==
+
+      integer  ilnblnk
+      external ilnblnk
+
+c     == end of interface ==
+
+      jtlo = mybylo(myThid)
+      jthi = mybyhi(myThid)
+      itlo = mybxlo(myThid)
+      ithi = mybxhi(myThid)
+      jmin = 1-oly
+      jmax = sny+oly
+      imin = 1-olx
+      imax = snx+olx
+
+c--     Set default values.
+      do ivar = 1,maxcvars
+       ncvarindex(ivar) = -1
+       ncvarrecs(ivar)  =  0
+       ncvarxmax(ivar)  =  0
+       ncvarymax(ivar)  =  0
+       ncvarnrmax(ivar) =  0
+       ncvargrd(ivar)   = '?'
+      enddo
+
+c     Set unit weight to 1
+c
+
+      do bj=1,nSy
+         do bi=1,nSx
+            do k=1,Nr
+             wunit(k,bi,bj) = 1. _d 0
+             do j=1-oly,sNy+oly
+              do i=1-olx,sNx+olx
+               loctmp3d(i,j,k,bi,bj) = 1. _d 0
+              enddo
+             enddo
+            enddo
+         enddo
+      enddo
+
+#ifdef ALLOW_AUTODIFF
+      call active_write_xyz( 'wunit', loctmp3d, 1, 0, mythid, dummy)
+#else
+      CALL WRITE_REC_XYZ_RL( 'wunit', loctmp3d, 1, 1, myThid )
+#endif
+
+      _BARRIER
+
+#ifdef ECCO_CTRL_DEPRECATED
+
+c--   =====================
+c--   Initial state fields.
+c--   =====================
+
+cph(
+cph    index  7-10 reserved for atmos. state,
+cph    index 11-14 reserved for open boundaries,
+cph    index 15-16 reserved for mixing coeff.
+cph    index 17    reserved for passive tracer TR1
+cph    index 18,19 reserved for sst, sss
+cph    index 20             for hFacC
+cph    index 21-22          for efluxy, efluxp
+cph    index 23             for bottom drag
+cph    index 24
+cph    index 25-26          for edtaux, edtauy
+cph    index 27-29          for uvel0, vvel0, etan0
+cph    index 30-31          for generic 2d, 3d field
+cph    index 32    reserved for precip (atmos. state)
+cph    index 33    reserved for swflux (atmos. state)
+cph    index 34    reserved for swdown (atmos. state)
+cph          35                 lwflux
+cph          36                 lwdown
+cph          37                 evap
+cph          38                 snowprecip
+cph          39                 apressure
+cph          40                 runoff
+cph          41                 seaice SIAREA
+cph          42                 seaice SIHEFF
+cph          43                 seaice SIHSNOW
+cph          44                 gmredi kapredi
+cph          45                 shelfice shifwflx
+cph          47-52              mean atmos. state
+cph)
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_THETA0_CONTROL
+c--   Initial state temperature contribution.
+      call ctrl_init_ctrlvar (
+     &     xx_theta_file, 1, 101, 1, 1, 1,
+     &     snx, sny, nr, 'c', '3d', myThid )
+#endif /* ALLOW_THETA0_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_SALT0_CONTROL
+c--   Initial state salinity contribution.
+      call ctrl_init_ctrlvar (
+     &     xx_salt_file, 2, 102, 1, 1, 1,
+     &     snx, sny, nr, 'c', '3d', myThid )
+#endif /* ALLOW_SALT0_CONTROL */
+
+c--   ===========================
+c--   Surface flux contributions.
+c--   ===========================
+
+c----------------------------------------------------------------------
+c--
+#if (defined (ALLOW_HFLUX_CONTROL))
+c--   Heat flux.
+      call ctrl_init_rec ( xx_hflux_file,
+     I     xx_hfluxstartdate1, xx_hfluxstartdate2, xx_hfluxperiod, 1,
+     O     xx_hfluxstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_hflux_file, 3, 103, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#elif (defined (ALLOW_ATEMP_CONTROL))
+c--   Atmos. temperature
+      call ctrl_init_rec ( xx_atemp_file,
+     I     xx_atempstartdate1, xx_atempstartdate2, xx_atempperiod, 1,
+     O     xx_atempstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_atemp_file, 7, 107, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#elif (defined (ALLOW_HFLUX0_CONTROL))
+c--   initial forcing only
+      call ctrl_init_ctrlvar (
+     &     xx_hflux_file, 3, 103, 1, 1, 1,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#endif /* ALLOW_HFLUX_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#if (defined (ALLOW_SFLUX_CONTROL))
+c--   Salt flux.
+      call ctrl_init_rec ( xx_sflux_file,
+     I     xx_sfluxstartdate1, xx_sfluxstartdate2, xx_sfluxperiod, 1,
+     O     xx_sfluxstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_sflux_file, 4, 104, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#elif (defined (ALLOW_AQH_CONTROL))
+c--   Atmos. humidity
+      call ctrl_init_rec ( xx_aqh_file,
+     I     xx_aqhstartdate1, xx_aqhstartdate2, xx_aqhperiod, 1,
+     O     xx_aqhstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_aqh_file, 8, 108, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#elif (defined (ALLOW_SFLUX0_CONTROL))
+c--   initial forcing only
+      call ctrl_init_ctrlvar (
+     &     xx_sflux_file, 4, 104, 1, 1, 1,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#endif /* ALLOW_SFLUX_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_EXF
+      IF ( .NOT.useAtmWind ) THEN
+#endif
+#if (defined (ALLOW_USTRESS_CONTROL))
+c--   Zonal wind stress.
+      call ctrl_init_rec ( xx_tauu_file,
+     I     xx_tauustartdate1, xx_tauustartdate2, xx_tauuperiod, 1,
+     O     xx_tauustartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_tauu_file, 5, 105, diffrec, startrec, endrec,
+#ifndef ALLOW_ROTATE_UV_CONTROLS
+     &     snx, sny, 1, 'w', 'xy', myThid )
+#else
+     &     snx, sny, 1, 'c', 'xy', myThid )
+#endif
+
+#elif (defined (ALLOW_TAUU0_CONTROL))
+c--   initial forcing only
+      call ctrl_init_ctrlvar (
+     &     xx_tauu_file, 5, 105, 1, 1, 1,
+     &     snx, sny, 1, 'w', 'xy', myThid )
+
+#endif /* ALLOW_USTRESS_CONTROL */
+#ifdef ALLOW_EXF
+      ENDIF
+#endif
+
+#if (defined (ALLOW_UWIND_CONTROL))
+#ifdef ALLOW_EXF
+      IF ( useAtmWind ) THEN 
+#endif
+c--   Zonal wind speed.
+      call ctrl_init_rec ( xx_uwind_file,
+     I     xx_uwindstartdate1, xx_uwindstartdate2, xx_uwindperiod, 1,
+     O     xx_uwindstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_uwind_file, 9, 109, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+#ifdef ALLOW_EXF
+      ENDIF
+#endif
+#endif /* ALLOW_UWIND_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_EXF
+      IF ( .NOT.useAtmWind ) THEN
+#endif
+#if (defined (ALLOW_VSTRESS_CONTROL))
+c--   Meridional wind stress.
+      call ctrl_init_rec ( xx_tauv_file,
+     I     xx_tauvstartdate1, xx_tauvstartdate2, xx_tauvperiod, 1,
+     O     xx_tauvstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_tauv_file, 6, 106, diffrec, startrec, endrec,
+#ifndef ALLOW_ROTATE_UV_CONTROLS
+     &     snx, sny, 1, 's', 'xy', myThid )
+#else
+     &     snx, sny, 1, 'c', 'xy', myThid )
+#endif
+
+#elif (defined (ALLOW_TAUV0_CONTROL))
+c--   initial forcing only
+      call ctrl_init_ctrlvar (
+     &     xx_tauv_file, 6, 106, 1, 1, 1,
+     &     snx, sny, 1, 's', 'xy', myThid )
+
+#endif /* ALLOW_VSTRESS_CONTROL */
+#ifdef ALLOW_EXF
+      ENDIF
+#endif
+
+#if (defined (ALLOW_VWIND_CONTROL))
+#ifdef ALLOW_EXF
+      IF ( useAtmWind ) THEN
+#endif
+c--   Meridional wind speed.
+      call ctrl_init_rec ( xx_vwind_file,
+     I     xx_vwindstartdate1, xx_vwindstartdate2, xx_vwindperiod, 1,
+     O     xx_vwindstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_vwind_file, 10, 110, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+#ifdef ALLOW_EXF
+      ENDIF
+#endif
+#endif /* ALLOW_VWIND_CONTROL */
+
+#endif /* ECCO_CTRL_DEPRECATED */
+
+c--   ===========================
+c--   Open boundary contributions.
+c--   ===========================
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_OBCSN_CONTROL
+c--   Northern obc.
+      call ctrl_init_rec ( xx_obcsn_file,
+     I     xx_obcsnstartdate1, xx_obcsnstartdate2, xx_obcsnperiod, 4,
+     O     xx_obcsnstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_obcsn_file, 11, 111, diffrec, startrec, endrec,
+     &     snx, 1, nr, 'm', 'xz', myThid )
+#endif /* ALLOW_OBCSN_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_OBCSS_CONTROL
+c--   Southern obc.
+      call ctrl_init_rec ( xx_obcss_file,
+     I     xx_obcssstartdate1, xx_obcssstartdate2, xx_obcssperiod, 4,
+     O     xx_obcssstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_obcss_file, 12, 112, diffrec, startrec, endrec,
+     &     snx, 1, nr, 'm', 'xz', myThid )
+#endif /* ALLOW_OBCSS_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_OBCSW_CONTROL
+c--   Western obc.
+      call ctrl_init_rec ( xx_obcsw_file,
+     I     xx_obcswstartdate1, xx_obcswstartdate2, xx_obcswperiod, 4,
+     O     xx_obcswstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_obcsw_file, 13, 113, diffrec, startrec, endrec,
+     &     1, sny, nr, 'm', 'yz', myThid )
+#endif  /* ALLOW_OBCSW_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_OBCSE_CONTROL
+c--   Eastern obc.
+      call ctrl_init_rec ( xx_obcse_file,
+     I     xx_obcsestartdate1, xx_obcsestartdate2, xx_obcseperiod, 4,
+     O     xx_obcsestartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_obcse_file, 14, 114, diffrec, startrec, endrec,
+     &     1, sny, nr, 'm', 'yz', myThid )
+#endif /* ALLOW_OBCSE_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_OBCS_CONTROL_MODES
+cih  Get matrices for reconstruction from barotropic-barclinic modes
+CMM  To use modes now hardcoded with ECCO_CPPOPTION.  Would be good to have
+c     run-time option and also define filename=baro_invmodes.bin
+        CALL MDSFINDUNIT( dUnit, myThid )
+        length_of_rec = MDS_RECLEN( 64, NR*NR, myThid )
+        open(dUnit, file='baro_invmodes.bin', status='old',
+     &         access='direct', recl=length_of_rec )
+        do j = 1,Nr
+           read(dUnit,rec=j) ((modesv(k,i,j), k=1,Nr), i=1,Nr)
+        end do
+        CLOSE( dUnit )
+CMM  double precision modesv is size [NR,NR,NR]
+c     dim one is z-space
+c     dim two is mode space
+c     dim three is the total depth for which this set of modes applies
+c     so for example modesv(:,2,nr) will be the second mode
+c     in z-space for the full model depth
+c    The modes are to be orthogonal when weighted by dz.
+c     i.e. if f_i(z) = mode i, sum_j(f_i(z_j)*f_j(z_j)*dz_j = delta_ij
+c    first mode should also be constant in depth...barotropic
+c    For a matlab code example how to construct the orthonormal modes,
+c     which are ideally the solution of planetary vertical mode equation
+c     using model mean dRho/dz, see
+c     MITgcm/verification/obcs_ctrl/input/gendata.m
+c    This code is compatible with partial cells
+#endif
+
+#ifdef ECCO_CTRL_DEPRECATED
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_DIFFKR_CONTROL
+      call ctrl_init_ctrlvar (
+     &     xx_diffkr_file, 15, 115, 1, 1, 1,
+     &     snx, sny, nr, 'c', '3d', myThid )
+#endif /* ALLOW_DIFFKR_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_KAPGM_CONTROL
+      call ctrl_init_ctrlvar (
+     &     xx_kapgm_file, 16, 116, 1, 1, 1,
+     &     snx, sny, nr, 'c', '3d', myThid )
+#endif /* ALLOW_KAPGM_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_TR10_CONTROL
+      call ctrl_init_ctrlvar (
+     &     xx_tr1_file, 17, 117, 1, 1, 1,
+     &     snx, sny, nr, 'c', '3d', myThid )
+#endif /* ALLOW_TR10_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#if (defined (ALLOW_SST_CONTROL))
+      call ctrl_init_rec ( xx_sst_file,
+     I     xx_sststartdate1, xx_sststartdate2, xx_sstperiod, 1,
+     O     xx_sststartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_sst_file, 18, 118, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#elif (defined (ALLOW_SST0_CONTROL))
+      call ctrl_init_ctrlvar (
+     &     xx_sst_file, 18, 118, 1, 1, 1,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#endif /* ALLOW_SST_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#if (defined (ALLOW_SSS_CONTROL))
+      call ctrl_init_rec ( xx_sss_file,
+     I     xx_sssstartdate1, xx_sssstartdate2, xx_sssperiod, 1,
+     O     xx_sssstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_sss_file, 19, 119, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#elif (defined (ALLOW_SSS0_CONTROL))
+      call ctrl_init_ctrlvar (
+     &     xx_sss_file, 19, 119, 1, 1, 1,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#endif /* ALLOW_SSS0_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_DEPTH_CONTROL
+        call ctrl_init_ctrlvar (
+     &       xx_depth_file, 20, 120, 1, 1, 1,
+     &       snx, sny,  1, 'c', 'xy', myThid )
+#endif /* ALLOW_DEPTH_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_EFLUXY0_CONTROL
+        call ctrl_init_ctrlvar (
+     &       xx_efluxy_file, 21, 121, 1, 1, 1,
+     &       snx, sny, nr, 's', '3d', myThid )
+#endif /* ALLOW_EFLUXY0_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_EFLUXP0_CONTROL
+        call ctrl_init_ctrlvar (
+     &       xx_efluxp_file, 22, 122, 1, 1, 1,
+     &       snx, sny, nr, 'v', '3d', myThid )
+#endif /* ALLOW_EFLUXP0_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_BOTTOMDRAG_CONTROL_NONGENERIC
+        call ctrl_init_ctrlvar (
+     &       xx_bottomdrag_file, 23, 123, 1, 1, 1,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+#endif /* ALLOW_BOTTOMDRAG_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_HFLUXM_CONTROL
+        call ctrl_init_ctrlvar (
+     &       xx_hfluxm_file, 24, 124, 1, 1, 1,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+#endif /* ALLOW_HFLUXM_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_EDDYPSI_CONTROL
+        call ctrl_init_ctrlvar (
+     &       xx_edtaux_file, 25, 125, 1, 1, 1,
+     &       snx, sny, nr, 'w', '3d', myThid )
+
+        call ctrl_init_ctrlvar (
+     &       xx_edtauy_file, 26, 126, 1, 1, 1,
+     &       snx, sny, nr, 's', '3d', myThid )
+#endif /* ALLOW_EDDYPSI_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_UVEL0_CONTROL
+        call ctrl_init_ctrlvar (
+     &       xx_uvel_file, 27, 127, 1, 1, 1,
+     &       snx, sny, nr, 'w', '3d', myThid )
+#endif /* ALLOW_UVEL0_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_VVEL0_CONTROL
+        call ctrl_init_ctrlvar (
+     &       xx_vvel_file, 28, 128, 1, 1, 1,
+     &       snx, sny, nr, 's', '3d', myThid )
+#endif /* ALLOW_VVEL0_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_ETAN0_CONTROL
+        call ctrl_init_ctrlvar (
+     &       xx_etan_file, 29, 129, 1, 1, 1,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+#endif /* ALLOW_VVEL0_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_GEN2D_CONTROL
+        call ctrl_init_ctrlvar (
+     &       xx_gen2d_file, 30, 130, 1, 1, 1,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+#endif /* ALLOW_GEN2D_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_GEN3D_CONTROL
+        call ctrl_init_ctrlvar (
+     &       xx_gen3d_file, 31, 131, 1, 1, 1,
+     &       snx, sny, nr, 'c', '3d', myThid )
+#endif /* ALLOW_GEN3D_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_PRECIP_CONTROL
+c--   Atmos. precipitation
+      call ctrl_init_rec ( xx_precip_file,
+     I     xx_precipstartdate1, xx_precipstartdate2, xx_precipperiod,1,
+     O     xx_precipstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_precip_file, 32, 132, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#endif /* ALLOW_PRECIP_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_SWFLUX_CONTROL
+c--   Atmos. swflux
+      call ctrl_init_rec ( xx_swflux_file,
+     I     xx_swfluxstartdate1, xx_swfluxstartdate2, xx_swfluxperiod, 1,
+     O     xx_swfluxstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_swflux_file, 33, 133, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#endif /* ALLOW_SWFLUX_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_SWDOWN_CONTROL
+c--   Atmos. swdown
+      call ctrl_init_rec ( xx_swdown_file,
+     I     xx_swdownstartdate1, xx_swdownstartdate2, xx_swdownperiod, 1,
+     O     xx_swdownstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_swdown_file, 34, 134, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#endif /* ALLOW_SWDOWN_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_LWFLUX_CONTROL
+c--   Atmos. lwflux
+      call ctrl_init_rec ( xx_lwflux_file,
+     I     xx_lwfluxstartdate1, xx_lwfluxstartdate2, xx_lwfluxperiod, 1,
+     O     xx_lwfluxstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_lwflux_file, 35, 135, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#endif /* ALLOW_LWFLUX_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_LWDOWN_CONTROL
+c--   Atmos. lwdown
+      call ctrl_init_rec ( xx_lwdown_file,
+     I     xx_lwdownstartdate1, xx_lwdownstartdate2, xx_lwdownperiod, 1,
+     O     xx_lwdownstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_lwdown_file, 36, 136, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#endif /* ALLOW_LWDOWN_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_EVAP_CONTROL
+c--   Atmos. evap
+      call ctrl_init_rec ( xx_evap_file,
+     I     xx_evapstartdate1, xx_evapstartdate2, xx_evapperiod, 1,
+     O     xx_evapstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_evap_file, 37, 137, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#endif /* ALLOW_EVAP_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_SNOWPRECIP_CONTROL
+c--   Atmos. snowprecip
+      call ctrl_init_rec ( xx_snowprecip_file,
+     I     xx_snowprecipstartdate1, xx_snowprecipstartdate2,
+     I     xx_snowprecipperiod, 1,
+     O     xx_snowprecipstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_snowprecip_file, 38, 138, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#endif /* ALLOW_SNOWPRECIP_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_APRESSURE_CONTROL
+c--   Atmos. apressure
+      call ctrl_init_rec ( xx_apressure_file,
+     I     xx_apressurestartdate1, xx_apressurestartdate2,
+     I     xx_apressureperiod, 1,
+     O     xx_apressurestartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_apressure_file, 39, 139, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+
+#endif /* ALLOW_APRESSURE_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_RUNOFF_CONTROL
+c--   Atmos. runoff
+      call ctrl_init_rec ( xx_runoff_file,
+     I     xx_runoffstartdate1, xx_runoffstartdate2, xx_runoffperiod, 1,
+     O     xx_runoffstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_runoff_file, 40, 140, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+#endif /* ALLOW_RUNOFF_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_SIAREA_CONTROL
+C--   so far there are no xx_siareastartdate1, etc., so we need to fudge it.
+CML      call ctrl_init_rec ( xx_siarea_file,
+CML     I     xx_siareastartdate1, xx_siareastartdate2, xx_siareaperiod, 1,
+CML     O     xx_siareastartdate, diffrec, startrec, endrec,
+CML     I     myThid )
+      startrec = 1
+      endrec   = 1
+      diffrec  = endrec - startrec + 1
+      call ctrl_init_ctrlvar (
+     &     xx_siarea_file, 41, 141, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+#endif /* ALLOW_siarea_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_SIHEFF_CONTROL
+C--   so far there are no xx_siheffstartdate1, etc., so we need to fudge it.
+CML      call ctrl_init_rec ( xx_siheff_file,
+CML     I     xx_siheffstartdate1, xx_siheffstartdate2, xx_siheffperiod, 1,
+CML     O     xx_siheffstartdate, diffrec, startrec, endrec,
+CML     I     myThid )
+      startrec = 1
+      endrec   = 1
+      diffrec  = endrec - startrec + 1
+      call ctrl_init_ctrlvar (
+     &     xx_siheff_file, 42, 142, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+#endif /* ALLOW_siheff_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_SIHSNOW_CONTROL
+C--   so far there are no xx_sihsnowstartdate1, etc., so we need to fudge it.
+CML      call ctrl_init_rec ( xx_sihsnow_file,
+CML     I     xx_sihsnowstartdate1, xx_sihsnowstartdate2, xx_sihsnowperiod, 1,
+CML     O     xx_sihsnowstartdate, diffrec, startrec, endrec,
+CML     I     myThid )
+      startrec = 1
+      endrec   = 1
+      diffrec  = endrec - startrec + 1
+      call ctrl_init_ctrlvar (
+     &     xx_sihsnow_file, 43, 143, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'c', 'xy', myThid )
+#endif /* ALLOW_sihsnow_CONTROL */
+
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_KAPREDI_CONTROL
+      call ctrl_init_ctrlvar (
+     &     xx_kapredi_file, 44, 144, 1, 1, 1,
+     &     snx, sny, nr, 'c', '3d', myThid )
+#endif /* ALLOW_KAPREDI_CONTROL */
+
+c----------------------------------------------------------------------
+c----------------------------------------------------------------------
+
+#ifdef ALLOW_SHIFWFLX_CONTROL
+c--   freshwater flux underneath ice-shelves
+      call ctrl_init_rec ( xx_shifwflx_file,
+     I     xx_shifwflxstartdate1, xx_shifwflxstartdate2,
+     I     xx_shifwflxperiod, 1,
+     O     xx_shifwflxstartdate, diffrec, startrec, endrec,
+     I     myThid )
+      call ctrl_init_ctrlvar (
+     &     xx_shifwflx_file, 45, 145, diffrec, startrec, endrec,
+     &     snx, sny, 1, 'i', 'xy', myThid )
+#endif /* ALLOW_SHIFWFLX_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_ATM_MEAN_CONTROL
+# ifdef ALLOW_ATEMP_CONTROL
+       call ctrl_init_ctrlvar (
+     &       xx_atemp_mean_file, 47, 147, 1, 1, 1,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+# endif
+# ifdef ALLOW_AQH_CONTROL
+       call ctrl_init_ctrlvar (
+     &       xx_aqh_mean_file,   48, 148, 1, 1, 1,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+# endif
+# ifdef ALLOW_UWIND_CONTROL
+       call ctrl_init_ctrlvar (
+     &       xx_uwind_mean_file, 49, 149, 1, 1, 1,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+# endif
+# ifdef ALLOW_VWIND_CONTROL
+       call ctrl_init_ctrlvar (
+     &       xx_vwind_mean_file, 50, 150, 1, 1, 1,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+# endif
+# ifdef ALLOW_PRECIP_CONTROL
+       call ctrl_init_ctrlvar (
+     &       xx_precip_mean_file,51, 151, 1, 1, 1,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+# endif
+# ifdef ALLOW_SWDOWN_CONTROL
+       call ctrl_init_ctrlvar (
+     &       xx_swdown_mean_file,52, 152, 1, 1, 1,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+# endif
+#endif /* ALLOW_ATM_MEAN_CONTROL */
+
+#endif /* ECCO_CTRL_DEPRECATED */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_GENARR2D_CONTROL
+       do iarr = 1, maxCtrlArr2D
+#ifndef ALLOW_OPENAD
+        if (xx_genarr2d_weight(iarr).NE.' ')
+     &  call ctrl_init_ctrlvar (
+#else
+        call ctrl_init_ctrlvar (
+#endif
+     &       xx_genarr2d_file(iarr)(1:MAX_LEN_FNAM),
+     &       100+iarr, 200+iarr, 1, 1, 1,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+
+       enddo
+#endif /* ALLOW_GENARR2D_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_GENARR3D_CONTROL
+       do iarr = 1, maxCtrlArr3D
+#ifndef ALLOW_OPENAD
+        if (xx_genarr3d_weight(iarr).NE.' ')
+     &  call ctrl_init_ctrlvar (
+#else
+        call ctrl_init_ctrlvar (
+#endif
+     &       xx_genarr3d_file(iarr)(1:MAX_LEN_FNAM),
+     &       200+iarr, 300+iarr, 1, 1, 1,
+     &       snx, sny, nr, 'c', '3d', myThid )
+       enddo
+#endif /* ALLOW_GENARR3D_CONTROL */
+
+c----------------------------------------------------------------------
+c--
+#ifdef ALLOW_GENTIM2D_CONTROL
+       do iarr = 1, maxCtrlTim2D
+
+#ifdef ALLOW_CAL
+        if (xx_gentim2d_startdate1(iarr).EQ.0) then
+          xx_gentim2d_startdate1(iarr)=startdate_1
+          xx_gentim2d_startdate2(iarr)=startdate_2
+        endif
+#endif
+
+        call ctrl_init_rec ( xx_gentim2d_file(iarr)(1:MAX_LEN_FNAM),
+     I       xx_gentim2d_startdate1(iarr), 
+     I       xx_gentim2d_startdate2(iarr), 
+     I       xx_gentim2d_period(iarr), 
+     I       1,
+     O       xx_gentim2d_startdate(1,iarr), 
+     O       diffrec, startrec, endrec,
+     I       myThid )
+C
+
+#ifndef ALLOW_OPENAD
+        if (xx_gentim2d_weight(iarr).NE.' ') then
+#endif
+        do k2 = 1, maxCtrlProc
+         if (xx_gentim2d_preproc(k2,iarr).EQ.'replicate')
+     &   xx_gentim2d_preproc(k2,iarr)='docycle'
+         if (xx_gentim2d_preproc(k2,iarr).EQ.'doglomean')
+     &   xx_gentim2d_glosum(iarr)     = .TRUE.
+         if (xx_gentim2d_preproc(k2,iarr).EQ.'documul')
+     &   xx_gentim2d_cumsum(iarr)     = .TRUE.
+        enddo
+C
+        diffrecFull=diffrec
+        endrecFull=endrec
+        do k2 = 1, maxCtrlProc
+         if (xx_gentim2d_preproc(k2,iarr).EQ.'docycle') then
+           if (xx_gentim2d_preproc_i(k2,iarr).NE.0) then
+            diffrec=min(diffrec,xx_gentim2d_preproc_i(k2,iarr))
+            endrec=min(endrec,xx_gentim2d_preproc_i(k2,iarr))
+           endif
+         endif
+        enddo
+C
+        ilgen=ilnblnk( xx_gentim2d_file(iarr) )
+        write(fnamegen(1:MAX_LEN_FNAM),'(2a)')
+     &       xx_gentim2d_file(iarr)(1:ilgen),'.effective'
+        call ctrl_init_ctrlvar (
+     &       fnamegen(1:MAX_LEN_FNAM),
+     &       300+iarr, 400+iarr,
+     &       diffrecFull, startrec, endrecFull,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+C
+        ilgen=ilnblnk( xx_gentim2d_file(iarr) )
+        write(fnamegen(1:MAX_LEN_FNAM),'(2a)')
+     &       xx_gentim2d_file(iarr)(1:ilgen),'.tmp'
+        call ctrl_init_ctrlvar (
+     &       fnamegen(1:MAX_LEN_FNAM),
+     &       300+iarr, 400+iarr,
+     &       diffrecFull, startrec, endrecFull,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+C
+        call ctrl_init_ctrlvar (
+     &       xx_gentim2d_file(iarr)(1:MAX_LEN_FNAM),
+     &       300+iarr, 400+iarr,
+     &       endrec, 1, endrec,
+     &       snx, sny, 1, 'c', 'xy', myThid )
+C
+#ifndef ALLOW_OPENAD
+       endif
+#endif
+C
+       enddo
+#endif /* ALLOW_GENTIM2D_CONTROL */
+
+c----------------------------------------------------------------------
+c----------------------------------------------------------------------
+
+      call ctrl_init_wet( myThid )
+
+c----------------------------------------------------------------------
+c----------------------------------------------------------------------
+
+#ifdef ALLOW_DIC_CONTROL
+      do i = 1, dic_n_control
+       xx_dic(i) = 0. _d 0
+      enddo
+#endif
+
+c----------------------------------------------------------------------
+c----------------------------------------------------------------------
+
+      do bj = jtlo,jthi
+       do bi = itlo,ithi
+        do j = jmin,jmax
+         do i = imin,imax
+          wareaunit (i,j,bi,bj) = 1.0
+#ifndef ALLOW_ECCO
+          whflux    (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wsflux    (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wtauu     (i,j,bi,bj) = maskW(i,j,1,bi,bj)
+          wtauv     (i,j,bi,bj) = maskS(i,j,1,bi,bj)
+          watemp    (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          waqh      (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wprecip   (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wswflux   (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wswdown   (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wuwind    (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wvwind    (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wlwflux   (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wlwdown   (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wevap     (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wsnowprecip(i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wapressure(i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wrunoff   (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wsst      (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+          wsss      (i,j,bi,bj) = maskC(i,j,1,bi,bj)
+#endif
+         enddo
+        enddo
+       enddo
+      enddo
+
+      _BARRIER
+
+c--   Summarize the cost function setup.
+      _BEGIN_MASTER( myThid )
+      call ctrl_summary( myThid )
+      _END_MASTER( myThid )
+
+      return
+      end

--- a/ECCOv4 Release 4/flux-forced/code/ctrl_map_ini_gentim2d.F
+++ b/ECCOv4 Release 4/flux-forced/code/ctrl_map_ini_gentim2d.F
@@ -1,0 +1,402 @@
+C $Header: /u/gcmpack/MITgcm/pkg/ctrl/ctrl_map_ini_gentim2d.F,v 1.15 2017/03/06 20:03:46 gforget Exp $
+C $Name:  $
+
+#include "CTRL_OPTIONS.h"
+#ifdef ALLOW_AUTODIFF
+# include "AUTODIFF_OPTIONS.h"
+#endif
+
+CBOP
+C     !ROUTINE: CTRL_MAP_INI_GENTIM2D
+C     !INTERFACE:
+      SUBROUTINE CTRL_MAP_INI_GENTIM2D( myThid )
+
+C     !DESCRIPTION: \bv
+C     *=================================================================
+C     | SUBROUTINE CTRL_MAP_INI_GENTIM2D
+C     | Dimensionalize and preprocess time variable controls.
+C     *=================================================================
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == global variables ==
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "GRID.h"
+#include "DYNVARS.h"
+#include "FFIELDS.h"
+#include "CTRL_SIZE.h"
+#include "ctrl.h"
+#include "optim.h"
+#include "ctrl_dummy.h"
+#include "CTRL_GENARR.h"
+#ifdef ALLOW_PTRACERS
+# include "PTRACERS_SIZE.h"
+# include "PTRACERS_FIELDS.h"
+#endif
+#ifdef ALLOW_AUTODIFF
+#include "tamc.h"
+#endif
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     == routine arguments ==
+      INTEGER myThid
+
+#ifdef ALLOW_GENTIM2D_CONTROL
+C     !LOCAL VARIABLES:
+C     == local variables ==
+      integer iarr
+      integer numsmo
+      character*(80) fnamegenIn
+      character*(80) fnamegenOut
+      character*(80) fnamegenTmp
+      character*(80) fnamebase
+      integer startrec
+      integer endrec
+      integer diffrec
+      integer irec, jrec, krec, lrec
+      integer replicated_nrec
+      integer replicated_ntimes
+      logical doglobalread
+      logical ladinit
+      logical dowc01
+      logical dosmooth
+      logical doscaling
+      _RL     xx_gen(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+#ifdef ALLOW_ECCO
+      _RL     xx_gen_tmp(1-olx:snx+olx,1-oly:sny+oly,nsx,nsy)
+      integer nyearsINT
+      _RL     nyearsRL
+#endif
+      integer bi,bj
+      integer i,j,k2
+      INTEGER  ILNBLNK
+      EXTERNAL ILNBLNK
+      integer ilgen
+CEOP
+
+c--   Now, read the control vector.
+      doglobalread = .false.
+      ladinit      = .false.
+
+      DO bj=myByLo(myThid), myByHi(myThid)
+       DO bi=myBxLo(myThid), myBxHi(myThid)
+        DO j = 1-OLy,sNy+OLy
+         DO i = 1-OLx,sNx+OLx
+          xx_gen(i,j,bi,bj)=0. _d 0
+         ENDDO
+        ENDDO
+       ENDDO
+      ENDDO
+
+C--   generic 2D control variables
+      DO iarr = 1, maxCtrlTim2D
+
+       diffrec=0
+       startrec=0
+       endrec=0
+
+#ifndef ALLOW_OPENAD
+       if (xx_gentim2d_weight(iarr).NE.' ') then
+#endif
+
+        fnamebase = xx_gentim2d_file(iarr)
+        call ctrl_init_rec ( fnamebase,
+     I       xx_gentim2d_startdate1(iarr),
+     I       xx_gentim2d_startdate2(iarr),
+     I       xx_gentim2d_period(iarr),
+     I       1,
+     O       xx_gentim2d_startdate(1,iarr),
+     O       diffrec, startrec, endrec,
+     I       myThid )
+
+catn: there is a copy of this code as ctrl_map_ini_gentim2dmd
+catn: so that this code is actually not called but a version of
+catn: it is found in ad_taf_output.  At the end of the above
+catn: ctrl_init_rec call, we find that [start,end,diff]rec
+catn: are 24,37,14.  So what we need to make sure next is that
+catn: when we read from xx_atemp.0000000001.data, read from
+catn: 24:37, then write out to xx_atemp.effective.0000000001.data
+catn: as 1:14.  Note that the version of this in ad_taf_output.f
+catn: strips all the misc write statements so it appears as if
+catn: we did not go past here, but we did.
+catn
+catn        write(*,*) 'AA: iarr,xx_gentim2d_startdate(1,iarr): ',
+catn     &              iarr,xx_gentim2d_startdate(1,iarr)
+catn
+
+        dosmooth=.false.
+        dowc01  = .false.
+        doscaling=.true.
+
+        numsmo=1
+        do k2 = 1, maxCtrlProc
+          if (xx_gentim2d_preproc(k2,iarr).EQ.'WC01') then
+             dowc01=.TRUE.
+             if (xx_gentim2d_preproc_i(k2,iarr).NE.0)
+     &           numsmo=xx_gentim2d_preproc_i(k2,iarr)
+          endif
+          if ((.NOT.dowc01).AND.
+     &        (xx_gentim2d_preproc(k2,iarr).EQ.'smooth')) then
+             dosmooth=.TRUE.
+             if (xx_gentim2d_preproc_i(k2,iarr).NE.0)
+     &           numsmo=xx_gentim2d_preproc_i(k2,iarr)
+          endif
+          if (xx_gentim2d_preproc(k2,iarr).EQ.'noscaling') then
+             doscaling=.FALSE.
+          endif
+        enddo
+
+        fnamebase = xx_gentim2d_file(iarr)
+        ilgen=ilnblnk( fnamebase )
+        write(fnamegenIn(1:80),'(2a,i10.10)')
+     &       fnamebase(1:ilgen),'.',optimcycle
+        write(fnamegenOut(1:80),'(2a,i10.10)')
+     &       fnamebase(1:ilgen),'.effective.',optimcycle
+        write(fnamegenTmp(1:80),'(2a,i10.10)')
+     &       fnamebase(1:ilgen),'.tmp.',optimcycle
+
+c-- docycle
+
+c        replicated_nrec=endrec
+        replicated_nrec=diffrec
+        replicated_ntimes=0
+        do k2 = 1, maxCtrlProc
+         if (xx_gentim2d_preproc(k2,iarr).EQ.'docycle') then
+           if (xx_gentim2d_preproc_i(k2,iarr).NE.0) then
+            replicated_nrec=min(diffrec,xx_gentim2d_preproc_i(k2,iarr))
+            replicated_ntimes=
+     &       int(float(diffrec)/float(replicated_nrec))
+            if (replicated_ntimes*replicated_nrec.LT.diffrec)
+     &      replicated_ntimes=replicated_ntimes+1
+            if (replicated_ntimes*replicated_nrec.GT.diffrec)
+     &      replicated_ntimes=replicated_ntimes-1
+           endif
+         endif
+        enddo
+
+        DO jrec = 1, replicated_ntimes+1
+        DO irec = 1, replicated_nrec
+#ifdef ALLOW_AUTODIFF
+CADJ STORE xx_gentim2d_dummy = ctrltape, key = 1 , kind = isbyte
+#endif
+        krec=replicated_nrec*(jrec-1)+irec
+        lrec=startrec+irec-1
+        IF (krec.LE.endrec) THEN
+catn         ilgen=ilnblnk( fnamegenIn )
+catn         write(*,*) 'AE: iarr,[i,j,k,l]rec: ',iarr,irec,jrec,lrec
+catn         write(*,*) 'AF: fnamegenIn: ', fnamegenIn(1:ilgen)
+catn: fnamegenIn is xx_atemp.0000000001, so we need to read
+catn: from 24:37, so need startrec+irec-1 instead of irec
+catn: in the call below
+catn: HOWEVER, the problem is that in the adjoint mode, the function
+catn  adactive_read_xy is called to read in adxx_atemp.0000000001
+catn  instead xx_atemp.0000000001, in which case the records need to
+catn  be 14:-1:1 instead of of 37:-1:24.  The question is how can we
+catn  separate that out? Can we make use of the flag
+catn  FORWARD_SIMULATION and REVERSE_SIMULATION?
+#ifdef ALLOW_AUTODIFF
+         call active_read_xy( fnamegenIn, xx_gen, lrec,
+     &                       doglobalread, ladinit, optimcycle,
+     &                       mythid, xx_gentim2d_dummy(iarr) )
+#else
+         CALL READ_REC_XY_RL( fnamegenIn, xx_gen, lRec, 1, myThid )
+#endif
+#ifdef ALLOW_AUTODIFF
+         call active_write_xy( fnamegenOut, xx_gen, krec, optimcycle,
+     &       mythid, xx_gentim2d_dummy(iarr) )
+#else
+         CALL WRITE_REC_XY_RL( fnamegenOut, xx_gen, iRec, 1, myThid )
+#endif
+        ENDIF
+        ENDDO
+        ENDDO
+
+c-- rmcycle
+#ifdef ALLOW_ECCO
+        replicated_nrec=endrec
+        replicated_ntimes=0
+        do k2 = 1, maxCtrlProc
+         if (xx_gentim2d_preproc(k2,iarr).EQ.'rmcycle') then
+           if (xx_gentim2d_preproc_i(k2,iarr).NE.0) then
+            replicated_nrec=min(endrec,xx_gentim2d_preproc_i(k2,iarr))
+            replicated_ntimes=
+     &       int(float(endrec)/float(replicated_nrec))
+            if (replicated_ntimes*replicated_nrec.LT.endrec)
+     &      replicated_ntimes=replicated_ntimes+1
+            if (replicated_ntimes*replicated_nrec.GT.endrec)
+     &      replicated_ntimes=replicated_ntimes-1
+           endif
+         endif
+        enddo
+
+c       print*,'endrec',endrec,replicated_ntimes,replicated_nrec
+
+        IF (replicated_ntimes.GT.0) THEN
+
+c create cyclic average
+
+        nyearsINT=1+int((endrec-replicated_nrec)/replicated_nrec)
+        nyearsRL=float(nyearsINT)
+
+c       print*,'nyearsINT',nyearsINT,nyearsRL
+
+        DO irec = 1, replicated_nrec
+
+         call ecco_zero(xx_gen,1,zeroRL,myThid)
+
+         do jrec=1,nyearsINT
+#ifdef ALLOW_AUTODIFF
+CADJ STORE xx_gentim2d_dummy = ctrltape, key = 1 , kind = isbyte
+#endif
+           krec=irec+(jrec-1)*replicated_nrec
+#ifdef ALLOW_AUTODIFF
+           call active_read_xy( fnamegenOut, xx_gen_tmp, krec,
+     &                       doglobalread, ladinit, optimcycle,
+     &                       mythid, xx_gentim2d_dummy(iarr) )
+#else
+           CALL READ_REC_XY_RL( fnamegenOut, xx_gen_tmp, krec, 
+     &                       1, myThid )
+#endif
+           call ecco_add(xx_gen_tmp,1,xx_gen,1,myThid)
+         enddo
+
+         call ecco_div(xx_gen,1,nyearsRL,myThid)
+
+#ifdef ALLOW_AUTODIFF
+CADJ STORE xx_gentim2d_dummy = ctrltape, key = 1 , kind = isbyte
+#endif
+
+#ifdef ALLOW_AUTODIFF
+         call active_write_xy( fnamegenTmp, xx_gen, iRec, optimcycle,
+     &       mythid, xx_gentim2d_dummy(iarr) )
+#else
+         CALL WRITE_REC_XY_RL( fnamegenTmp, xx_gen, iRec, 1, myThid )
+#endif
+
+        ENDDO
+
+c subtract cyclic average
+        DO jrec = 1, replicated_ntimes+1
+        DO irec = 1, replicated_nrec
+#ifdef ALLOW_AUTODIFF
+CADJ STORE xx_gentim2d_dummy = ctrltape, key = 1 , kind = isbyte
+#endif
+        krec=replicated_nrec*(jrec-1)+irec
+        IF (krec.LE.endrec) THEN
+#ifdef ALLOW_AUTODIFF
+         CALL active_read_xy( fnamegenOut, xx_gen, kRec,
+     &                       doglobalread, ladinit, optimcycle,
+     &                       mythid, xx_gentim2d_dummy(iarr) )
+#else
+         CALL READ_REC_XY_RL( fnamegenOut, xx_gen, kRec, 1, myThid )
+#endif
+#ifdef ALLOW_AUTODIFF
+         CALL active_read_xy( fnamegenTmp, xx_gen_tmp, iRec,
+     &                       doglobalread, ladinit, optimcycle,
+     &                       mythid, xx_gentim2d_dummy(iarr) )
+#else
+         CALL READ_REC_XY_RL( fnamegenTmp, xx_gen_tmp, iRec, 1, myThid )
+#endif
+         CALL ecco_subtract(xx_gen_tmp,1,xx_gen,1,myThid)
+#ifdef ALLOW_AUTODIFF
+         CALL active_write_xy( fnamegenOut, xx_gen, kRec, optimcycle,
+     &       mythid, xx_gentim2d_dummy(iarr) )
+#else
+         CALL WRITE_REC_XY_RL( fnamegenOut, xx_gen, kRec, 1, myThid )
+#endif
+        ENDIF
+        ENDDO
+        ENDDO
+
+        ENDIF
+#endif /* ifdef ALLOW_ECCO */
+
+c-- scaling and smoothing
+
+catn: so, the fix for xx_atemp.0000000001 was already above
+catn: From now on, we read in from xx_atemp.effective.0000000001
+catn: so we no longer need to fix any record from here on out
+        DO irec = 1, diffrec
+#ifdef ALLOW_AUTODIFF
+CADJ STORE xx_gentim2d_dummy = ctrltape, key = 1 , kind = isbyte
+#endif
+
+#ifdef ALLOW_AUTODIFF
+         call active_read_xy( fnamegenOut, xx_gen, irec,
+     &                       doglobalread, ladinit, optimcycle,
+     &                       mythid, xx_gentim2d_dummy(iarr) )
+#else
+         CALL READ_REC_XY_RL( fnamegenOut, xx_gen, iRec, 1, myThid )
+#endif
+
+#ifndef ALLOW_OPENAD
+         jrec=1
+catn: what should we do with the timevariable weights? do we ever
+catn: have this situation?  not sure how to fix this.  The fix
+catn: needs to be inside the do k2 loop
+         do k2 = 1, maxCtrlProc
+          if (xx_gentim2d_preproc(k2,iarr).EQ.'variaweight') then
+catn            jrec=irec
+            jrec=startrec+irec-1
+          endif
+         enddo
+         call mdsreadfield( xx_gentim2d_weight(iarr), ctrlprec, 'RL',
+     &     1, wgentim2d(1-Olx,1-Oly,1,1,iarr), jrec, myThid )
+
+#ifdef ALLOW_SMOOTH
+         IF (useSMOOTH) THEN
+          IF (dowc01) call smooth_correl2d(xx_gen,maskC,numsmo,mythid)
+          IF (dosmooth) call smooth2d(xx_gen,maskC,numsmo,mythid)
+         ENDIF
+#endif /* ALLOW_SMOOTH */
+
+         IF (doscaling) then
+         DO bj=myByLo(myThid), myByHi(myThid)
+          DO bi=myBxLo(myThid), myBxHi(myThid)
+           DO j = 1,sNy
+            DO i = 1,sNx
+             if ((maskC(i,j,1,bi,bj).NE.0.).AND.
+     &           (wgentim2d(i,j,bi,bj,iarr).GT.0.)) then
+                xx_gen(i,j,bi,bj)=xx_gen(i,j,bi,bj)
+     &                  /sqrt(wgentim2d(i,j,bi,bj,iarr))
+             else
+                xx_gen(i,j,bi,bj)=0. _d 0
+             endif
+            ENDDO
+           ENDDO
+          ENDDO
+         ENDDO
+         ENDIF ! IF (doscaling) then
+#endif /* ALLOW_OPENAD */
+
+         CALL CTRL_BOUND_2D(xx_gen,maskC,
+     &        xx_gentim2d_bounds(1,iarr),myThid)
+
+         CALL EXCH_XY_RL ( xx_gen , myThid )
+
+#ifdef ALLOW_AUTODIFF
+         call active_write_xy( fnamegenOut, xx_gen, irec, optimcycle,
+     &       mythid, xx_gentim2d_dummy(iarr) )
+#else
+         CALL WRITE_REC_XY_RL( fnamegenOut, xx_gen, iRec, 1, myThid )
+#endif
+
+c-- end irec loop
+        ENDDO
+
+#ifndef ALLOW_OPENAD
+       endif
+#endif
+
+c-- end iarr loop
+      ENDDO
+
+#endif /* ALLOW_GENTIM2D_CONTROL */
+
+      RETURN
+      END
+

--- a/ECCOv4 Release 4/flux-forced/code/ecco_init_varia.F
+++ b/ECCOv4 Release 4/flux-forced/code/ecco_init_varia.F
@@ -1,0 +1,70 @@
+#include "ECCO_OPTIONS.h"
+#include "AD_CONFIG.h"
+
+      SUBROUTINE ECCO_INIT_VARIA( myThid )
+
+C     ==================================================================
+C     SUBROUTINE ecco_init_varia
+C     ==================================================================
+C
+C     o Initialise ecco variables.
+C
+C     ==================================================================
+C     SUBROUTINE ecco_cost_init_varia
+C     ==================================================================
+
+      IMPLICIT NONE
+
+C     == global variables ==
+#include "EEPARAMS.h"
+#include "SIZE.h"
+#include "PARAMS.h"
+#include "GRID.h"
+#include "ecco_cost.h"
+#ifdef ALLOW_COST
+# include "cost.h"
+#endif
+
+C     == routine arguments ==
+      INTEGER myThid
+
+C     == local variables ==
+
+C     == end of interface ==
+
+#ifdef ALLOW_PSBAR_STERIC
+# ifndef ALLOW_AUTODIFF
+      _BEGIN_MASTER(myThid)
+# endif
+      RHOsumGlob_0 = 0. _d 0
+      VOLsumGlob_0 = 0. _d 0
+# ifndef ALLOW_AUTODIFF
+      _END_MASTER(myThid)
+# endif
+      IF ( .NOT. ( startTime .EQ. baseTime .AND.  nIter0 .EQ. 0
+     &     .AND. pickupSuff .EQ. ' ') ) THEN
+        CALL ECCO_READ_PICKUP ( nIter0, myThid )
+      ENDIF
+#endif /* ALLOW_PSBAR_STERIC */
+
+      CALL ECCO_PHYS( myThid )
+
+#ifdef ALLOW_PSBAR_STERIC
+C RHO/VOLsumGlob_0 are zeros if S/R ECCO_READ_PICKUP is not called
+C or pickup files (pickup_ecco.*.data/meta) do not exist. Assign
+C RHO/VOLsumGlob calculated in S/R ECCO_PHYS to RHO/VOLsumGlob_0.
+      _BEGIN_MASTER(myThid)
+      IF ( RHOsumGlob_0 .EQ. 0. _d 0 .AND.
+     &     VOLsumGlob_0 .EQ. 0. _d 0 ) THEN
+        RHOsumGlob_0 = RHOsumGlob
+        VOLsumGlob_0 = VOLsumGlob
+      ENDIF
+      _END_MASTER(myThid)
+#endif
+
+      CALL ECCO_COST_INIT_VARIA( myThid )
+
+      _BARRIER
+
+      RETURN
+      END

--- a/ECCOv4 Release 4/flux-forced/code/ecco_phys.F
+++ b/ECCOv4 Release 4/flux-forced/code/ecco_phys.F
@@ -86,7 +86,7 @@ c need to include halos for find_rho_2d
      O                RHOInSituLoc(1-OLx,1-OLy,k,bi,bj),
      I                k, bi, bj, myThid )
           enddo
-        enddo
+       enddo
       enddo
 
       DO bj=myByLo(myThid),myByHi(myThid)

--- a/ECCOv4 Release 4/flux-forced/code/ecco_read_pickup.F
+++ b/ECCOv4 Release 4/flux-forced/code/ecco_read_pickup.F
@@ -1,0 +1,109 @@
+#include "ECCO_OPTIONS.h"
+
+CBOP
+C     !ROUTINE: ECCO_READ_PICKUP
+C     !INTERFACE:
+      SUBROUTINE ECCO_READ_PICKUP( myIter, myThid )
+
+C     !DESCRIPTION: \bv
+C     *================================================================*
+C     | SUBROUTINE ECCO_READ_PICKUP
+C     | o read ecco pickups
+C     *================================================================*
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+C     === Global variables ===
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#ifdef ALLOW_ECCO
+# ifdef ECCO_CTRL_DEPRECATED
+#  include "ecco_cost.h"
+# else
+#  include "ecco.h"
+# endif
+#endif
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     myThid :: my Thread Id number
+      INTEGER myIter
+      INTEGER myThid
+
+#ifdef ALLOW_PSBAR_STERIC
+C !FUNCTIONS:
+      INTEGER ILNBLNK
+      EXTERNAL ILNBLNK
+
+C     !LOCAL VARIABLES:
+      CHARACTER*(MAX_LEN_FNAM) fn, fntmp
+      CHARACTER*(10) suff
+      CHARACTER*(MAX_LEN_MBUF) msgBuf
+      INTEGER prec, IL, ioUnit
+      LOGICAL exst
+      _RL tmparr(2), dummyRS(1)
+CEOP
+
+C--   Suffix for pickup files
+      IF (pickupSuff.EQ.' ') THEN
+        IF ( rwSuffixType.EQ.0 ) THEN
+          WRITE(suff,'(I10.10)') myIter
+        ELSE
+          CALL RW_GET_SUFFIX( suff, startTime, myIter, myThid )
+        ENDIF
+      ELSE
+        WRITE(suff,'(A10)') pickupSuff
+      ENDIF
+
+      _BEGIN_MASTER(myThid)
+
+      WRITE(fn,'(A,A10)') 'pickup_ecco.', suff
+c#ifdef ALLOW_MDSIO
+c       useCurrentDir = .FALSE.
+c       CALL MDS_CHECK4FILE(
+c    I                       fn, '.data', 'ECCO_READ_PICKUP',
+c    O                       filNam, fileExist,
+c    I                       useCurrentDir, myThid )
+c#endif
+C-    Check first for global file with simple name (ie. fn)
+      INQUIRE( file=fn, exist=exst )
+      IF ( .NOT.exst ) THEN
+C-    Check for global file with ".data" suffix
+        IL  = ILNBLNK( fn )
+        WRITE(fntmp,'(2A)') fn(1:IL),'.data'
+        INQUIRE( file=fntmp, exist=exst )
+      ENDIF
+
+      IF (exst) THEN
+        ioUnit = 0
+        prec = precFloat64
+#ifdef ALLOW_MDSIO
+        CALL MDS_READVEC_LOC( fn, prec, ioUnit, 'RL',
+     &                        2, tmparr, dummyRS, 0, 0, 1, myThid )
+#else
+        STOP 'ABNORMAL END: S/R ECCO_READ_PICKUP: Needs MDSIO pkg'
+#endif
+        VOLsumGlob_0 = tmparr(1)
+        RHOsumGlob_0 = tmparr(2)
+      ELSE
+        WRITE(msgBuf,'(2A)') 'ECCO_READ_PICKUP: ',
+     &        fn(1:IL)//' and '//fntmp(1:iL+5)//' not provided.'
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        WRITE(msgBuf,'(2A,I10)') 'ECCO_READ_PICKUP: ',
+     &   'sterGloH is referenced to its value at time step:', nIter0
+        CALL PRINT_MESSAGE( msgBuf, standardMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+        CALL PRINT_MESSAGE( msgBuf, errorMessageUnit,
+     &                      SQUEEZE_RIGHT, myThid )
+      ENDIF
+
+      _END_MASTER(myThid)
+
+#endif /*  ALLOW_PSBAR_STERIC  */
+
+      RETURN
+      END

--- a/ECCOv4 Release 4/flux-forced/code/ecco_write_pickup.F
+++ b/ECCOv4 Release 4/flux-forced/code/ecco_write_pickup.F
@@ -1,0 +1,70 @@
+#include "ECCO_OPTIONS.h"
+
+CBOP
+C     !ROUTINE: ECCO_WRITE_PICKUP
+C     !INTERFACE:
+      SUBROUTINE ECCO_WRITE_PICKUP( permPickup, suff,
+     I                              myTime, myIter, myThid )
+
+C     !DESCRIPTION: \bv
+C     *================================================================*
+C     | SUBROUTINE ECCO_WRITE_PICKUP
+C     | o write ecco pickups
+C     *================================================================*
+C     \ev
+
+C     !USES:
+      IMPLICIT NONE
+C     === Global variables ===
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#ifdef ALLOW_ECCO
+# ifdef ECCO_CTRL_DEPRECATED
+#  include "ecco_cost.h"
+# else
+#  include "ecco.h"
+# endif
+#endif
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     permPickup :: write a permanent pickup
+C     suff    :: suffix for pickup file (eg. ckptA or 0000000010)
+C     myTime  :: Current time in simulation
+C     myIter  :: Current iteration number in simulation
+C     myThid  :: My Thread Id number
+      LOGICAL permPickup
+      CHARACTER*(*) suff
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
+
+#ifdef ALLOW_PSBAR_STERIC
+C     !LOCAL VARIABLES:
+      CHARACTER*(MAX_LEN_FNAM) fn
+c     CHARACTER*(MAX_LEN_MBUF) msgBuf
+      INTEGER prec, ioUnit
+      _RL tmparr(2), dummyRS(1)
+CEOP
+
+      WRITE(fn,'(A,A10)') 'pickup_ecco.',suff
+      IF ( fn .NE. ' ' ) THEN
+        ioUnit = 0
+        prec = precFloat64
+
+        tmparr(1) = VOLsumGlob_0
+        tmparr(2) = RHOsumGlob_0
+#ifdef ALLOW_MDSIO
+        CALL MDS_WRITEVEC_LOC(
+     I             fn, prec, ioUnit,
+     I             'RL', 2, tmparr, dummyRS,
+     I             0, 0, 1, myIter, myThid )
+#else
+        STOP 'ABNORMAL END: S/R ECCO_WRITE_PICKUP: Needs MDSIO pkg'
+#endif
+      ENDIF
+
+#endif /*  ALLOW_PSBAR_STERIC  */
+
+      RETURN
+      END

--- a/ECCOv4 Release 4/flux-forced/code/packages_write_pickup.F
+++ b/ECCOv4 Release 4/flux-forced/code/packages_write_pickup.F
@@ -1,0 +1,256 @@
+C $Header: /u/gcmpack/MITgcm/model/src/packages_write_pickup.F,v 1.45 2017/03/24 23:26:10 jmc Exp $
+C $Name:  $
+
+#include "PACKAGES_CONFIG.h"
+#include "CPP_OPTIONS.h"
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|
+C     files.
+
+CBOP
+C     !ROUTINE: PACKAGES_WRITE_PICKUP
+
+C     !INTERFACE:
+      SUBROUTINE PACKAGES_WRITE_PICKUP(
+     I                    permPickup, suffix,
+     I                    myTime, myIter, myThid )
+
+C     !DESCRIPTION:
+C     Write pickup files for each package which needs it to restart.
+C     This routine (S/R PACKAGES_WRITE_PICKUP) calls per-package
+C     write-pickup (or checkpoint) routines.  It writes both
+C     "rolling-pickup" files (ckptA,ckptB) and permanent pickup.
+
+C     !CALLING SEQUENCE:
+C     PACKAGES_WRITE_PICKUP
+C       |
+C       |-- GAD_WRITE_PICKUP
+C       |
+C       |-- CD_CODE_WRITE_PICKUP
+C       |
+C       |-- OBCS_WRITE_PICKUP
+C       |
+C       |-- GGL90_WRITE_PICKUP
+C       |
+C       |-- BBL_WRITE_PICKUP
+C       |
+C       |-- CHEAPAML_WRITE_PICKUP
+C       |
+C       |-- FLT_WRITE_PICKUP
+C       |
+C       |-- PTRACERS_WRITE_PICKUP
+C       |
+C       |-- GCHEM_WRITE_PICKUP
+C       |
+C       |-- SEAICE_WRITE_PICKUP
+C       |
+C       |-- STREAMICE_WRITE_PICKUP
+C       |
+C       |-- THSICE_WRITE_PICKUP
+C       |
+C       |-- LAND_WRITE_PICKUP
+C       |
+C       |-- ATM_PHYS_WRITE_PICKUP
+C       |
+C       |-- FIZHI_WRITE_PICKUP
+C       |-- FIZHI_WRITE_VEGTILES
+C       |-- FIZHI_WRITE_DATETIME
+C       |
+C       |-- DIAGNOSTICS_WRITE_PICKUP
+C       |
+C       |-- GMREDI_WRITE_PICKUP
+C       |
+C       |-- CPL_WRITE_PICKUP
+C       |
+C       |-- MYPACKAGE_WRITE_PICKUP
+
+C     !USES:
+      IMPLICIT NONE
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "RESTART.h"
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     permPickup :: Is or is not a permanent pickup.
+C     suffix     :: pickup-name suffix
+C     myTime     :: Current time of simulation ( s )
+C     myIter     :: Iteration number
+C     myThid     :: Thread number for this instance of the routine.
+      LOGICAL permPickup
+      CHARACTER*(*) suffix
+      _RL     myTime
+      INTEGER myIter
+      INTEGER myThid
+
+C     !LOCAL VARIABLES:
+CEOP
+
+C     Going to really do some IO. Make everyone except master thread wait.
+C     this is done within IO routines => no longer needed
+c     _BARRIER
+
+#ifdef ALLOW_GENERIC_ADVDIFF
+C     Write restart file for 2nd-Order moment (active) Tracers
+      IF ( useGAD ) THEN
+        CALL GAD_WRITE_PICKUP(
+     I                 suffix, myTime, myIter, myThid )
+      ENDIF
+#endif /* ALLOW_GENERIC_ADVDIFF */
+
+#ifdef ALLOW_CD_CODE
+      IF (useCDscheme) THEN
+        CALL CD_CODE_WRITE_PICKUP( permPickup,
+     I                     suffix, myTime, myIter, myThid )
+      ENDIF
+#endif /* ALLOW_CD_CODE */
+
+#ifdef  ALLOW_OBCS
+      IF (useOBCS) THEN
+        CALL OBCS_WRITE_PICKUP(
+     &                  suffix, myTime, myIter, myThid )
+      ENDIF
+#endif  /* ALLOW_OBCS */
+
+#ifdef  ALLOW_GGL90
+      IF ( useGGL90 ) THEN
+        CALL GGL90_WRITE_PICKUP( permPickup,
+     I                      suffix, myTime, myIter, myThid )
+      ENDIF
+#endif  /* ALLOW_GGL90 */
+
+#ifdef ALLOW_BBL
+      IF (useBBL) THEN
+        CALL BBL_WRITE_PICKUP( permPickup,
+     I                      suffix, myTime, myIter, myThid )
+      ENDIF
+#endif /* ALLOW_MYPACKAGE */
+
+#ifdef ALLOW_CHEAPAML
+C     Write restart file for CHEAPAML pkg
+      IF ( useCheapAML ) THEN
+         CALL CHEAPAML_WRITE_PICKUP( permPickup,
+     I                      suffix, myTime, myIter, myThid)
+       ENDIF
+#endif /* ALLOW_CHEAPAML */
+
+#ifdef ALLOW_FLT
+C     Write restart file for floats
+      IF (useFLT) THEN
+        CALL FLT_WRITE_PICKUP(
+     &                  suffix, myTime, myIter, myThid )
+      ENDIF
+#endif
+
+#ifdef ALLOW_PTRACERS
+C     Write restart file for passive tracers
+      IF (usePTRACERS) THEN
+        CALL PTRACERS_WRITE_PICKUP( permPickup,
+     I                      suffix, myTime, myIter, myThid )
+      ENDIF
+#endif /* ALLOW_PTRACERS */
+
+#ifdef ALLOW_GCHEM
+C     Write restart file for GCHEM pkg & GCHEM sub-packages
+      IF ( useGCHEM ) THEN
+        CALL GCHEM_WRITE_PICKUP( permPickup,
+     I                      suffix, myTime, myIter, myThid )
+      ENDIF
+#endif
+
+#ifdef  ALLOW_SEAICE
+      IF ( useSEAICE ) THEN
+        CALL SEAICE_WRITE_PICKUP( permPickup,
+     I                    suffix, myTime, myIter, myThid )
+      ENDIF
+#endif  /* ALLOW_SEAICE */
+
+#ifdef ALLOW_STREAMICE
+      IF (useStreamIce) THEN
+        CALL STREAMICE_WRITE_PICKUP( permPickup,
+     I                    suffix, myTime, myIter, myThid )
+      ENDIF
+#endif
+
+#ifdef ALLOW_SHELFICE
+      IF (useShelfIce) THEN
+        CALL SHELFICE_WRITE_PICKUP( permPickup,
+     I                    suffix, myTime, myIter, myThid )
+      ENDIF
+#endif
+
+#ifdef ALLOW_THSICE
+      IF (useThSIce) THEN
+        CALL THSICE_WRITE_PICKUP( permPickup,
+     I                    suffix, myTime, myIter, myThid )
+      ENDIF
+#endif /* ALLOW_THSICE */
+
+#ifdef ALLOW_LAND
+C     Write pickup file for Land package:
+      IF (useLand) THEN
+        CALL LAND_WRITE_PICKUP( permPickup,
+     &                  suffix, myTime, myIter, myThid )
+      ENDIF
+#endif
+
+#ifdef ALLOW_ATM_PHYS
+      IF ( useAtm_Phys ) THEN
+        CALL ATM_PHYS_WRITE_PICKUP( permPickup,
+     I                      suffix, myTime, myIter, myThid )
+      ENDIF
+#endif /* ALLOW_ATM_PHYS */
+
+#ifdef ALLOW_FIZHI
+C     Write pickup file for fizhi package
+      IF (usefizhi) THEN
+        CALL FIZHI_WRITE_PICKUP(suffix,myTime,myIter,myThid)
+        CALL FIZHI_WRITE_VEGTILES(suffix,0,myTime,myIter,myThid)
+        CALL FIZHI_WRITE_DATETIME(myTime,myIter,myThid)
+      ENDIF
+#endif
+
+#ifdef ALLOW_DIAGNOSTICS
+C     Write pickup file for diagnostics package
+      IF (useDiagnostics) THEN
+        CALL DIAGNOSTICS_WRITE_PICKUP( permPickup,
+     I                         suffix, myTime, myIter, myThid )
+      ENDIF
+#endif
+
+#ifdef ALLOW_GMREDI
+      IF ( useGMRedi ) THEN
+        CALL GMREDI_WRITE_PICKUP( permPickup,
+     I                            suffix, myTime, myIter, myThid )
+      ENDIF
+#endif
+
+#ifdef  COMPONENT_MODULE
+      IF (useCoupler) THEN
+        CALL CPL_WRITE_PICKUP(
+     &                 suffix, myTime, myIter, myThid )
+      ENDIF
+#endif  /* COMPONENT_MODULE */
+
+#ifdef ALLOW_MYPACKAGE
+      IF (useMYPACKAGE) THEN
+        CALL MYPACKAGE_WRITE_PICKUP( permPickup,
+     I                      suffix, myTime, myIter, myThid )
+      ENDIF
+#endif /* ALLOW_MYPACKAGE */
+
+#ifdef ALLOW_ECCO
+      IF (useECCO) THEN
+        CALL ECCO_WRITE_PICKUP( permPickup,
+     I                      suffix, myTime, myIter, myThid )
+      ENDIF
+#endif /* ALLOW_ECCO */
+
+C--   Every one else must wait until writing is done.
+C     this is done within IO routines => no longer needed
+c     _BARRIER
+
+      RETURN
+      END
+
+C---+----1----+----2----+----3----+----4----+----5----+----6----+----7-|--+----|

--- a/ECCOv4 Release 4/flux-forced/code/the_model_main.F
+++ b/ECCOv4 Release 4/flux-forced/code/the_model_main.F
@@ -1,0 +1,779 @@
+C $Header: /u/gcmpack/MITgcm/model/src/the_model_main.F,v 1.122 2015/01/20 15:00:55 dgoldberg Exp $
+C $Name:  $
+
+CBOI
+C
+C !TITLE: MITGCM KERNEL CODE SYNOPSIS
+C !AUTHORS: mitgcm developers ( support@mitgcm.org )
+C !AFFILIATION: Massachussetts Institute of Technology
+C !DATE:
+C !INTRODUCTION: Kernel dynamical routines
+C This document summarises MITgcm code under the model/ subdirectory.
+C The code under model/ ( src/ and inc/ ) contains most of
+C the driver routines for the baseline forms of the kernel equations in the
+C MITgcm algorithm. Numerical code for much of the baseline forms of
+C these equations is also under the model/ directory. Other numerical code
+C used for the kernel equations is contained in packages in the pkg/
+C directory tree.
+C Code for auxiliary equations and alternate discretizations of the kernel
+C equations and algorithm can also be found in the pkg/ directory tree.
+C
+C \subsection{Getting Help and Reporting Errors and Problems}
+C If you have questions please subscribe and e-mail support@mitgcm.org.
+C We also welcome reports of errors and inconsistencies in the code or
+C in the accompanying documentation. Please feel free to send these
+C to support@mitgcm.org. For further information and to review
+C problems reported to support@mitgcm.org please visit http://mitgcm.org.
+C
+C \subsection{MITgcm Kernel Code Calling Sequence}
+C \bv
+C
+C Invocation from WRAPPER level...
+C
+C  |
+C  |-THE_MODEL_MAIN :: Primary driver for the MITgcm algorithm
+C    |              :: Called from WRAPPER level numerical
+C    |              :: code invocation routine. On entry
+C    |              :: to THE_MODEL_MAIN separate thread and
+C    |              :: separate processes will have been established.
+C    |              :: Each thread and process will have a unique ID
+C    |              :: but as yet it will not be associated with a
+C    |              :: specific region in decomposed discrete space.
+C    |
+C    |-INITIALISE_FIXED :: Set fixed model arrays such as topography,
+C    | |                :: grid, solver matrices etc..
+C    | |
+C    | |-INI_PARMS :: Routine to set kernel model parameters.
+C    | |           :: Kernel parameters are read from file "data"
+C    | |           :: in directory in which code executes.
+C    | |
+C    | |-PACKAGES_BOOT      :: Start up the optional package environment.
+C    | |                    :: Runtime selection of active packages.
+C    | |-PACKAGES_READPARMS :: read each package input parameter file
+C    | | |- ${PKG}_READPARMS
+C    | |
+C    | |-SET_PARMS :: Finalise model parameter setting (if fct of pkg usage)
+C    | |
+C    | |-INI_MODEL_IO   :: Initialise Input/Output setting
+C    | |  |-MNC_INIT    :: Initialise MITgcm NetCDF interface (MNC)(see pkg/mnc)
+C    | |  |-MNC_CW_INIT :: Initialise MNC grid and variable types  (see pkg/mnc)
+C    | |  |-MON_INIT    :: Initialises monitor package ( see pkg/monitor )
+C    | |
+C    | |-INI_GRID       :: Control grid array (vert. and horiz.) initialisation.
+C    | | |              :: Grid arrays are held and described in GRID.h.
+C    | | |-LOAD_GRID_SPACING    :: Load grid spacing (vector) from files
+C    | | |-INI_VERTICAL_GRID    :: Set up vertical grid and coordinate
+C    | | |-INI_CARTESIAN_GRID   :: Cartesian horiz. grid initialisation
+C    | | |                      :: (calculate grid from kernel parameters).
+C    | | |-INI_SPHERICAL_POLAR_GRID :: Spherical polar horiz. grid setting
+C    | | |                          :: (calculate grid from kernel parameters).
+C    | | |-INI_CURVILINEAR_GRID :: General orthogonal, structured horiz. grid
+C    | | |                      :: initialisation; input from raw grid files
+C    | | |                      :: (LONC.bin, LATC.bin, DXF.bin, ... ) or per
+C    | | |                      :: face file: horizGridFile(.faceXXX.bin)
+C    | | |-INI_CYLINDER_GRID    :: Cylindrical horiz. grid setting
+C    | |
+C    | |-LOAD_REF_FILES   :: Read-in reference vertical profiles (T,S,Rho)
+C    | |-INI_EOS          :: Initialise Equation Of State (EOS) coefficients
+C    | |-SET_REF_STATE    :: Set reference pressure/geopotential, reference
+C    | |                  :: stratification (for implicit IGW), vertical
+C    | |                  :: velocity scaling factor and anelastic ref. density
+C    | |-SET_GRID_FACTORS :: Set grid factors (fct of k) for deep-atmosphere
+C    | |
+C    | |-INI_DEPTHS    :: Read (from "bathyFile") or set bathymetry/orography.
+C    | |-INI_MASKS_ETC :: Derive horizontal and vertical cell fractions and
+C    | |               :: land masking for solid-fluid boundaries.
+C    | |
+C    | |-PACKAGES_INIT_FIXED  :: do all packages fixed-initialisation setting
+C    | | |- ${PKG}_INIT_FIXED
+C    | |
+C    | |-INI_GLOBAL_DOMAIN :: Initialise domain related (global) quantities.
+C    | |-INI_LINEAR_PHISURF :: Set ref. surface Bo_surf
+C    | |
+C    | |-INI_CORI          :: Set coriolis term. zero, f-plane, beta-plane,
+C    | |                   :: sphere options are coded.
+C    | |-INI_CG2D          :: 2D conjugate grad solver initialisation.
+C    | |-INI_CG3D          :: 3D conjugate grad solver initialisation.
+C    | |
+C    | |-CONFIG_SUMMARY    :: Provide synopsis of kernel setup. Includes
+C    | |                   :: annotated table of kernel parameter settings.
+C    | |
+C    | |-PACKAGES_CHECK    :: call each package configuration checking S/R
+C    | | |- ${PKG}_CHECK
+C    | |
+C    | |-CONFIG_CHECK      :: Check config and parameter consistency.
+C    | |
+C    | |-WRITE_GRID        :: write grid fields to output files
+C    | |-CPL_EXCH_CONFIGS  :: exchange config with coupler-interface
+C    |
+C    |-CTRL_UNPACK         :: Control vector support package. see pkg/ctrl
+C    |-COST_DEPENDENT_INIT :: ( see pkg/cost )
+C    |
+C    |-ADTHE_MAIN_LOOP :: Derivative evaluating form of main time stepping loop
+C    !                 :: Automatically generated by TAMC/TAF.
+C    |
+C    |-THE_MAIN_LOOP   :: Main timestepping loop routine.
+C    | |
+C    | |-INITIALISE_VARIA :: Set the initial conditions for time evolving fields
+C    | | |
+C #ifdef ALLOW_AUTODIFF
+C    | | |-INI_DEPTHS         \
+C    | | |-CTRL_DEPTH_INI      \
+C    | | |-UPDATE_MASKS_ETC     } ALLOW_DEPTH_CONTROL case
+C    | | |-UPDATE_CG2D         /
+C #endif
+C    | | |-INI_NLFS_VARS :: Initialise all Non-Lin Free-Surf arrays (SURFACE.h)
+C    | | |-INI_DYNVARS   :: Initialise to zero all DYNVARS.h arrays
+C    | | |-INI_NH_VARS   :: Initialise to zero all NH_VARS.h arrays
+C    | | |
+C    | | |-INI_FIELDS    :: Control initialising model fields to non-zero
+C    | | | |-INI_VEL     :: Initialize 3D flow field.
+C    | | | |-INI_THETA   :: Set model initial temperature field.
+C    | | | |-INI_SALT    :: Set model initial salinity field.
+C    | | | |-INI_PSURF   :: Set model initial free-surface height/pressure.
+C    | | | |-READ_PICKUP :: Read in main model pickup files to restart a run.
+C    | | |
+C    | | |-INI_MIXING   :: Initialise diapycnal diffusivity.
+C    | | |
+C    | | |-INI_FORCING  :: Set model initial forcing fields, either
+C    | | |   |          :: set in-line or from file as shown here:
+C    | | |   |-READ_FLD_XY_RS(zonalWindFile)
+C    | | |   |-READ_FLD_XY_RS(meridWindFile)
+C    | | |   |-READ_FLD_XY_RS(surfQnetFile)
+C    | | |   |-READ_FLD_XY_RS(EmPmRfile)
+C    | | |   |-READ_FLD_XY_RS(thetaClimFile)
+C    | | |   |-READ_FLD_XY_RS(saltClimFile)
+C    | | |   |-READ_FLD_XY_RS(surfQswFile)
+C    | | |
+C    | | |-AUTODIFF_INIT_VARIA :: (see pkg/autodiff )
+C    | | |
+C    | | |-PACKAGES_INIT_VARIABLES :: Does initialisation of time evolving
+C    | | | | ${PKG}_INIT_VARIA     :: package data.
+C    | | |
+C    | | |-COST_INIT_VARIA     :: ( see pkg/cost )
+C    | | |-CONVECTIVE_ADJUSTMENT_INI :: Apply conv. adjustment to initial state
+C    | | |
+C    | | |-CALC_R_STAR    :: Calculate the new level thickness factor (r* coord)
+C    | | |-UPDATE_R_STAR  :: Update the level thickness fraction (r* coord).
+C    | | |-UPDATE_SIGMA   :: Update the level thickness fraction (sigma-coord).
+C    | | |-CALC_SURF_DR   :: Calculate the new surface level thickness.
+C    | | |-UPDATE_SURF_DR :: Update the surface-level thickness fraction.
+C    | | |
+C    | | |-UPDATE_CG2D    :: Update 2D conjugate grad. for Free-Surf.
+C    | | |
+C    | | |-INTEGR_CONTINUITY :: Integrate the continuity Equation
+C    | | | |-INTEGRATE_FOR_W :: Integrate for vertical velocity
+C    | | | |-OBCS_APPLY_W    :: Open boundary package (see pkg/obcs).
+C    | | | |-UPDATE_ETAH     :: Update Surface height/pressure
+C    | | |
+C    | | |-CALC_R_STAR    :: Calculate the new level thickness factor (r* coord)
+C    | | |-CALC_SURF_DR   :: Calculate the new surface level thickness.
+C    | | |
+C    | | |-STATE_SUMMARY    :: Summarise model prognostic variables.
+C    | | |
+C    | | |-MONITOR          :: Monitor state (see pkg/monitor)
+C    | | |
+C    | | |-DO_STATEVARS_TAVE :: Time averaging package ( see pkg/timeave ).
+C    | | |  |-TIMEAVE_STATVARS :: Accumulate main model state variables
+C    | | |  |-PTRACERS_TIMEAVE :: Accumulate passive tracers variables
+C    | | |
+C    | | |-DO_THE_MODEL_IO  :: Controlling routine for IO
+C    | | | |-WRITE_STATE    ::  Write model state variables.
+C    | | | |-TIMEAVE_STATV_WRITE :: Write Time averaged output (see pkg/timeave)
+C    | | | |-FIZHI_WRITE_STATE :: Write Fizhi pkg output (see pkg/fizhi)
+C    | | | |-AIM_WRITE_TAVE    :: Write AIM  pkg output (see pkg/aim_v23)
+C    | | | |-LAND_OUTPUT       :: Write Land pkg output (see pkg/land)
+C    | | | |-OBCS_OUTPUT       :: Write OBCS pkg output (see pkg/obcs)
+C    | | | |-GMREDI_OUTPUT     :: Write GM-Redi pkg output (see pkg/gmredi)
+C    | | | |-KPP_OUTPUT        :: Write KPP  pkg output (see pkg/kpp)
+C    | | | |-PP81_OUTPUT       :: Write PP81 pkg output (see pkg/pp81)
+C    | | | |-KL10_OUTPUT       :: Write KL10 pkg output (see pkg/kl10)
+C    | | | |-MY82_OUTPUT       :: Write MY82 pkg output (see pkg/my82)
+C    | | | |-OPPS_OUTPUT       :: Write OPPS pkg output (see pkg/opps)
+C    | | | |-GGL90_OUTPUT      :: Write GGL90 pkg output (see pkg/ggl90)
+C    | | | |-SBO_CALC          :: Compute SBO diagnostics (see pkg/sbo)
+C    | | | |-SBO_OUTPUT        :: Write SBO  pkg output   (see pkg/sbo)
+C    | | | |-SEAICE_OUTPUT     :: Write SeaIce pkg output (see pkg/seaice)
+C    | | | |-SHELFICE_OUTPUT   :: Write ShelfIce pkg output (see pkg/shelfice)
+C    | | | |-BULKF_OUTPUT      :: Write Bulk-Force output (see pkg/bulK_force)
+C    | | | |-THSICE_OUTPUT     :: Write ThSIce pkg output (see pkg/thsice)
+C    | | | |-PTRACERS_OUTPUT   :: Write pTracers pkg output (see pkg/ptracers)
+C    | | | |-MATRIX_OUTPUT     :: Write Matrix pkg output (see pkg/matrix)
+C    | | | |-GCHEM_OUTPUT      :: Write Geochemistry pkg output (see pkg/gchem)
+C    | | | |-CPL_OUTPUT        :: Write Coupler-Interface output (see
+C    | | | |                   :: pkg/atm_compon_interf, pkg/ocn_compon_interf)
+C    | | | |-LAYERS_CALC       :: Calculate layers diagnostics (see pkg/layers)
+C    | | | |-LAYERS_OUTPUT     :: Write Layers pkg output (see pkg/layers)
+C    | | | |-DIAGNOSTICS_WRITE :: Write pkg/diagnostics output
+C    | | |
+C====|>| ****************************
+C====|>| BEGIN MAIN TIMESTEPPING LOOP
+C====|>| ****************************
+C    | |-COST_AVERAGESFIELDS :: time-averaged Cost function terms (see pkg/cost)
+C    | |-PROFILES_INLOOP     :: ( see pkg/profiles )
+C    | /
+C    | |-MAIN_DO_LOOP    :: Open-AD case: Main timestepping loop routine
+C    | \                    otherwise: just call FORWARD_STEP
+C    | |
+C/\  | |-FORWARD_STEP        :: Step forward a time-step ( AT LAST !!! )
+C/\  | | |
+C/\  | | |-AUTODIFF_INADMODE_UNSET :: Set/reset some adjoint flags
+C/\  | | |-RESET_NLFS_VARS   :: Reset some Non-Lin Free-Surf vars (Adjoint)
+C/\  | | |-UPDATE_R_STAR     :: Reset r-star factor variables     (Adjoint)
+C/\  | | |-UPDATE_SURF_DR    :: Reset NLFS surface thickness vars (Adjoint)
+C/\  | | |
+C/\  | | |-PTRACERS_SWITCH_ONOFF    :: Set/reset pTracers time-stepping switch
+C/\  | | |-DIAGNOSTICS_SWITCH_ONOFF :: Activate/de-activate diagnostics
+C/\  | | |-DO_STATEVARS_DIAGS ( 0 ) :: fill-up state variable diagnostics
+C/\  | | |
+C/\  | | |-NEST_CHILD_SETMEMO :: Nesting interface
+C/\  | | |-NEST_PARENT_IO_1   :: Nesting interface
+C/\  | | |
+C/\  | | |-LOAD_FIELDS_DRIVER :: Control loading of input fields from files
+C/\  | | |
+C/\  | | |-BULKF_FORCING      :: Calculate surface forcing (see pkg/bulk_force)
+C/\  | | |-CHEAPAML           :: Cheap AML driver ( see pkg/cheapaml )
+C/\  | | |-CTRL_MAP_FORCING   :: Control vector support package. (see pkg/ctrl)
+C/\  | | |-DUMMY_IN_STEPPING  :: Autodiff package ( pkg/autodiff ).
+C/\  | | |
+C/\  | | |-CPL_EXPORT_MY_DATA :: Send coupling fields to coupler
+C/\  | | |-CPL_IMPORT_EXTERNAL_DATA :: Receive coupling fields from coupler
+C/\  | | |
+C/\  | | |-OASIS_PUT     :: Oasis coupler interface
+C/\  | | |-OASIS_GET     :: Oasis coupler interface
+C/\  | | |
+C/\  | | |-EBM_DRIVER    :: Calculate EBM type atmospheric forcing (see pkg/ebm)
+C/\  | | |
+C/\  | | |-DO_ATMOSPHERIC_PHYS :: Atmospheric physics computation
+C/\  | | | |
+C/\  | | | |-UPDATE_OCEAN_EXPORTS     :: ( see pkg/fizhi )
+C/\  | | | |-UPDATE_EARTH_EXPORTS     :: ( see pkg/fizhi )
+C/\  | | | |-UPDATE_CHEMISTRY_EXPORTS :: ( see pkg/fizhi )
+C/\  | | | |-FIZHI_WRAPPER            :: ( see pkg/fizhi )
+C/\  | | | |-STEP_FIZHI_FG            :: ( see pkg/fizhi )
+C/\  | | | |-FIZHI_UPDATE_TIME        :: ( see pkg/fizhi )
+C/\  | | | |
+C/\  | | | |-ATM_PHYS_DRIVER          :: ( see pkg/atm_phys )
+C/\  | | | |
+C/\  | | | |-AIM_DO_PHYSICS           :: ( see pkg/aim_v23 )
+C/\  | | |
+C/\  | | |-DO_OCEANIC_PHYS     :: Oceanic (& seaice) physics computation
+C/\  | | | |
+C/\  | | | |-OBCS_CALC         :: Open boundary. package (see pkg/obcs).
+C/\  | | | |
+C/\  | | | |-FRAZIL_CALC_RHS   :: Compute FRAZIL tendencies ( see pkg/frazil )
+C/\  | | | |-THSICE_MAIN       :: Thermodynamic sea-ice driver (see pkg/thsice)
+C/\  | | | |-SEAICE_MODEL      :: Sea-ice model driver (see pkg/seaice )
+C/\  | | | |-SEAICE_COST_SENSI   :: Sea-ice cost-function (see pkg/seaice )
+C/\  | | | |-SHELFICE_THERMODYNAMICS :: Compute ShelfIce thermo (pkg/shelfice)
+C/\  | | | |-ICEFRONT_THERMODYNAMICS :: Compute IceFront thermo (pkg/icefront)
+C/\  | | | |
+C/\  | | | |-SALT_PLUME_DO_EXCH   :: (see pkg/salt_plume )
+C/\  | | | |-FREEZE_SURFACE       :: Prevent SST to fall below TFreeze
+C/\  | | | |-OCN_APPLY_IMPORT     :: Apply imported fields from coupler
+C/\  | | | |-EXTERNAL_FORCING_SURF:: Compute appropriately dimensioned
+C/\  | | | |                      :: surface forcing terms.
+C/\  | | | |-FIND_RHO_2D @ p(k)   :: Calculate [rho(T,S,p)-Rho_0] of a slice
+C/\  | | | |-FIND_RHO_2D @ p(k-1) :: Calculate [rho(T,S,p)-Rho_0] of a slice
+C/\  | | | |-GRAD_SIGMA           :: Calculate isoneutral gradients
+C/\  | | | |-CALC_IVDC       :: Set Implicit Vertical Diffusivity for Convection
+C/\  | | | |-CALC_OCE_MXLAYER        :: Diagnose Oceanic Mixed Layer depth
+C/\  | | | |
+C/\  | | | |-SALT_PLUME_CALC_DEPTH   :: (see pkg/salt_plume )
+C/\  | | | |-SALT_PLUME_VOLFRAC      :: (see pkg/salt_plume )
+C/\  | | | |-SALT_PLUME_APPLY (Temp) :: (see pkg/salt_plume )
+C/\  | | | |-SALT_PLUME_APPLY (Salt) :: (see pkg/salt_plume )
+C/\  | | | |-SALT_PLUME_FORCING_SURF :: (see pkg/salt_plume )
+C/\  | | | |-KPP_CALC           :: Compute KPP  vertical mixing ( see pkg/kpp )
+C/\  | | | |-PP81_CALC          :: Compute PP81 vertical mixing ( see pkg/pp81 )
+C/\  | | | |-KL10_CALC          :: Compute KL10 vertical mixing ( see pkg/kl10 )
+C/\  | | | |-MY82_CALC          :: Compute MY82 vertical mixing ( see pkg/kl10 )
+C/\  | | | |-GGL90_CALC         :: Compute GGL90 vertical mixing (see pkg/ggl10)
+C/\  | | | |-GMREDI_CALC_TENSOR :: Compute GM-Redi tensor ( see pkg/gmredi )
+C/\  | | | |-DWNSLP_CALC_FLOW   :: Compute Down-Slope flow  (see pkg/down_slope)
+C/\  | | | |-BBL_CALC_RHS       :: Compute BBL tendencies ( see pkg/bbl )
+C/\  | | | |-MYPACKAGE_CALC_RHS :: Compute mypackage tendencies (pkg/mypackage)
+C/\  | | | |-ECCO_WRITE_PICKUP  :: Write ECCO pickups     (see pkg/ecco)
+C/\  | | | |
+C/\  | | | |-GMREDI_DO_EXCH     :: ( see pkg/gmredi )
+C/\  | | | |-KPP_DO_EXCH        :: ( see pkg/kpp )
+C/\  | | | |-DIAGS_RHO_G        :: Compute some density related diagnostics
+C/\  | | | |-DIAGS_OCEANIC_SURF_FLUX :: Diagnose oceanic surface fluxes
+C/\  | | | |-SALT_PLUME_DIAGNOSTICS_FILL :: (see pkg/salt_plume )
+C/\  | | | |-ECCO_PHYS          :: ( see pkg/ecco )
+C/\  | | |
+C/\  | | |-STREAMICE_TIMESTEP   :: ( see pkg/streamice )
+C/\  | | |
+C/\  | | |-GCHEM_CALC_TENDENCY  :: geochemistry driver routine (see pkg/gchem)
+C/\  | | |
+C/\  | | |-LONGSTEP_AVERAGE        :: Averaging state vars ( see pkg/longstep )
+C/\  | | |-LONGSTEP_THERMODYNAMICS :: Step forward tracers ( see pkg/longstep )
+C/\  | | |
+C/\  | | |-THERMODYNAMICS       :: theta, salt + tracer equations driver.
+C/\  | | | |                         (synchronous time-stepping case)
+C/\  | | | |-CALC_WSURF_TR          :: Compute T & S Linear-Free-Surf correction
+C/\  | | | |-PTRACERS_CALC_WSURF_TR :: Compute Tracers Linear-Free-Surf correct.
+C/\  | | | |
+C/\  | | | |-GMREDI_RESIDUAL_FLOW :: Get the flow field used to advect tracers
+C/\  | | | |
+C/\  | | | |-TEMP_INTEGRATE       :: Step forward Prognostic Eq for Temperature.
+C/\  | | | | |
+C/\  | | | | |-ADAMS_BASHFORTH3   :: Extrapolate tracer forward in time (AB-3)
+C/\  | | | | |-ADAMS_BASHFORTH2   :: Extrapolate tracer forward in time (AB-2)
+C/\  | | | | |-CALC_3D_DIFFUSIVITY :: set vertical diffusivity
+C/\  | | | | |
+C/\  | | | | |-GAD_SOM_ADVECT     :: Second Order Moment (SOM) advection
+C/\  | | | | |-GAD_ADVECTION      :: Generalised advection driver (multi-dim
+C/\  | | | | |                         advection case) (see pkg/gad).
+C/\  | | | | |-CALC_ADV_FLOW      :: set 3-D flow field to advect tracer
+C/\  | | | | |-APPLY_FORCING_T    :: Problem specific forcing for temperature.
+C/\  | | | | |-GAD_CALC_RHS       :: Calculate Advection-Diffusion tendency terms
+C/\  | | | | |
+C/\  | | | | |-ADAMS_BASHFORTH3   :: Extrapolate tendency forward in time (AB-3)
+C/\  | | | | |-ADAMS_BASHFORTH2   :: Extrapolate tendency forward in time (AB-2)
+C/\  | | | | |-FREESURF_RESCALE_G :: Re-scale Gt for free-surface height.
+C/\  | | | | |-DWNSLP_APPLY       :: Add pkg/down_slope tendency
+C/\  | | | | |
+C/\  | | | | |-TIMESTEP_TRACER    :: Step tracer field forward in time
+C/\  | | | | |
+C/\  | | | | |-GAD_IMPLICIT_R     :: Solve vertical implicit Advect-Diffus. eqn.
+C/\  | | | | |-IMPLDIFF           :: Solve vertical implicit diffusion equation.
+C/\  | | | | |-CYCLE_AB_TRACER    :: Cycle time-stepping arrays for tracer field
+C/\  | | | | |-CYCLE_TRACER       :: Cycle time-stepping arrays for tracer field
+C/\  | | | |
+C/\  | | | |-SALT_INTEGRATE       :: Step forward Prognostic Eq for Salinity.
+C/\  | | | | |                       same sequence of calls as in TEMP_INTEGRATE
+C/\  | | | |
+C/\  | | | |-PTRACERS_INTEGRATE   :: Integrate other tracer(s) (see pkg/ptracers).
+C/\  | | | | |                       same sequence of calls as in TEMP_INTEGRATE
+C/\  | | | | |-OBCS_APPLY_PTRACER :: Open boundary package for pTracers
+C/\  | | | |
+C/\  | | | |-OBCS_APPLY_TS        :: Open boundary package (see pkg/obcs ).
+C/\  | | |
+C/\  | | |-LONGSTEP_AVERAGE        :: Averaging state vars ( see pkg/longstep )
+C/\  | | |-LONGSTEP_THERMODYNAMICS :: Step forward tracers ( see pkg/longstep )
+C/\  | | |
+C/\  | | |-DO_STAGGER_FIELDS_EXCHANGES :: Update overlap regions of arrays
+C/\  | | |                                 Theta & Salt (implicit IGW case)
+C/\  | | |
+C/\  | | |-DYNAMICS       :: Momentum equations driver.
+C/\  | | | |
+C/\  | | | |-CALC_GRAD_PHI_SURF :: Calculate the gradient of the surface
+C/\  | | | |                       Potential anomaly.
+C/\  | | | |-CALC_VISCOSITY   :: Calculate net vertical viscosity
+C/\  | | | |-MOM_CALC_3D_STRAIN :: Calculates the strain tensor of 3D flow field
+C/\  | | | |-OBCS_COPY_UV_N   :: for Stevens bndary Conditions (see pkg/obcs)
+C/\  | | | |
+C/\  | | | |-CALC_PHI_HYD     :: Integrate the hydrostatic relation.
+C/\  | | | |-MOM_FLUXFORM     :: Flux Form momentum eqn. (pkg/mom_fluxform)
+C/\  | | | |-MOM_VECINV       :: Vector Invariant momentum eqn (pkg/mom_vecinv)
+C/\  | | | |-MOM_CALC_SMAG_3D :: Calculate Smagorinsky 3D (harmonic) viscosities
+C/\  | | | |-MOM_UV_SMAG_3D   :: Calculate U,V mom. tendency due to Smag 3D Visc
+C/\  | | | |-TIMESTEP         :: Step horizontal momentum fields forward in time
+C/\  | | | |
+C/\  | | | |-MOM_U_IMPLICIT_R :: Solve implicitly vertical Adv-Diffus equation.
+C/\  | | | |-IMPLDIFF         :: Solve vertical implicit diffusion equation.
+C/\  | | | |-OBCS_SAVE_UV_N   :: for Stevens bndary Conditions (see pkg/obcs)
+C/\  | | | |-OBCS_APPLY_UV    :: Apply Open bndary Conditions to provisional U,V
+C/\  | | | |-IMPLDIFF         :: (CD-Scheme) Solve vertical impl. diffus. eqn
+C/\  | | | |
+C/\  | | | |-CALC_GW          :: Vert. momentum tendency terms (Non-Hydrostatic)
+C/\  | | | | |-MOM_W_SMAG_3D  :: Calculate W mom. tendency due to Smag 3D Visc
+C/\  | | | |-TIMESTEP_WVEL    :: Step vert mom forward in time (Non-Hydrostatic)
+C/\  | | |
+C/\  | | |-MNC_UPDATE_TIME    :: Update MNC time record (see pkg/mnc)
+C/\  | | |
+C/\  | | |-UPDATE_R_STAR  :: Update the level thickness fraction (r* coord).
+C/\  | | |-UPDATE_SIGMA   :: Update the level thickness fraction (sigma-coord).
+C/\  | | |-UPDATE_R_STAR  :: Update the level thickness fraction.
+C/\  | | |-UPDATE_SURF_DR :: Update the surface-level thickness fraction.
+C/\  | | |-UPDATE_CG2D    :: Update 2D conjugate grad. for Free-Surf.
+C/\  | | |
+C/\  | | |-SHAP_FILT_APPLY_UV  :: Apply Shapiro Filter to provisional velocity
+C/\  | | |-ZONAL_FILT_APPLY_UV :: Apply  Zonal  Filter to provisional velocity
+C/\  | | |
+C/\  | | |-SOLVE_FOR_PRESSURE  :: Find surface pressure.
+C/\  | | | |-CALC_DIV_GHAT     :: Form the RHS of the surface pressure eqn.
+C/\  | | | |-CG2D              :: Two-dim pre-con. conjugate-gradient.
+C/\  | | | |-PRE_CG3D          :: Finish to set the RHS of the 3-D pressure eqn.
+C/\  | | | |-CG3D              :: Three-dim pre-con. conjugate-gradient solver.
+C/\  | | | |-POST_CG3D         :: finalise solution of NH and Free-Surf pressure
+C/\  | | |
+C/\  | | |-MOMENTUM_CORRECTION_STEP :: Finalise momentum stepping
+C/\  | | | |-CALC_GRAD_PHI_SURF  :: Return DDx and DDy of surface pressure
+C/\  | | | |-CORRECTION_STEP     :: Pressure correction to momentum
+C/\  | | | |-OBCS_APPLY_UV       :: Open boundary package (see pkg/obcs).
+C/\  | | | |-SHAP_FILT_APPLY_UV  :: Apply Shapiro Filter to latest velocity
+C/\  | | | |-ZONAL_FILT_APPLY_UV :: Apply  Zonal  Filter to latest velocity
+C/\  | | |
+C/\  | | |-INTEGR_CONTINUITY   :: Integrate continuity equation (see above)
+C/\  | | |
+C/\  | | |-CALC_R_STAR    :: Calculate the new level thickness factor (r* coord)
+C/\  | | |-CALC_SURF_DR   :: Calculate the new surface level thickness.
+C/\  | | |
+C/\  | | |-DO_STAGGER_FIELDS_EXCHANGES :: Update overlap regions of arrays
+C/\  | | |                             uVel,vVel & wVel (stagger-time-step case)
+C/\  | | |
+C/\  | | |-DO_STATEVARS_DIAGS ( 1 ) :: fill-up state variable diagnostics
+C/\  | | |
+C/\  | | |-THERMODYNAMICS       :: theta, salt + tracer Eq. driver (see above).
+C/\  | | |                         (staggered time-stepping case)
+C/\  | | |
+C/\  | | |-TRACERS_CORRECTION_STEP :: Finalise tracer stepping:
+C/\  | | | |                       ::  apply filter, conv.adjustment
+C/\  | | | |-TRACERS_IIGW_CORRECTION :: apply Implicit IGW adjustment to T & S
+C/\  | | | |-SHAP_FILT_APPLY_TS        :: Apply Shapiro Filter to latest T & S
+C/\  | | | |-ZONAL_FILT_APPLY_TS       :: Apply  Zonal  Filter to latest T & S
+C/\  | | | |-PTRACERS_ZONAL_FILT_APPLY :: Apply  Zonal Filter to pTracers
+C/\  | | | |-SALT_FILL                 :: Fill up negative Salt
+C/\  | | | |-OPPS_INTERFACE            :: ( see pkg/opps )
+C/\  | | | |-CONVECTIVE_ADJUSTMENT     :: Apply convective adjustment
+C/\  | | | |-MATRIX_STORE_TENDENCY_IMP :: ( see pkg/matrix )
+C/\  | | |
+C/\  | | |-LONGSTEP_AVERAGE        :: Averaging state vars ( see pkg/longstep )
+C/\  | | |-LONGSTEP_THERMODYNAMICS :: Step forward tracers ( see pkg/longstep )
+C/\  | | |
+C/\  | | |-GCHEM_FORCING_SEP :: Tracer forcing for gchem pkg (if tracer
+C/\  | | |                   :: dependent tendencies calculated separately)
+C/\  | | |
+C/\  | | |-DO_FIELDS_BLOCKING_EXCHANGES :: Sync up overlap regions.
+C/\  | | |
+C/\  | | |-DO_STATEVARS_DIAGS ( 2 ) :: fill-up state variable diagnostics
+C/\  | | |
+C/\  | | |-GRIDALT_UPDATE    :: ( see pkg/gridalt )
+C/\  | | |-STEP_FIZHI_CORR   :: ( see pkg/fizhi )
+C/\  | | |
+C/\  | | |-FLT_MAIN          :: Step forward Floats (see pkg/flt)
+C/\  | | |
+C/\  | | |-DO_STATEVARS_TAVE :: Time averaging package (see above)
+C/\  | | |
+C/\  | | |-NEST_PARENT_IO_2  :: Nesting interface
+C/\  | | |-NEST_CHILD_TRANSP :: Nesting interface
+C/\  | | |
+C/\  | | |-MONITOR          :: Monitor package (pkg/monitor).
+C/\  | | |
+C/\  | | |-COST_TILE        :: ( see pkg/cost )
+C/\  | | |
+C/\  | | |-DO_THE_MODEL_IO  :: Controlling routine for IO (see above)
+C/\  | | |
+C/\  | | |-PTRACERS_RESET   :: Re-initialize PTRACERS ( see pkg/ptracers )
+C/\  | | |
+C/\  | | |-DO_WRITE_PICKUP  :: Controlling routine for writing files to restart
+C/\  | | | |-PACKAGES_WRITE_PICKUP :: Write pickup files for each package
+C/\  | | | | |                     ::  which needs it to restart
+C/\  | | | | |-GAD_WRITE_PICKUP       :: Write Generic AdvDiff pickups for SOM
+C/\  | | | | |                        :: advection scheme (pkg/generic_advdiff)
+C/\  | | | | |-CD_CODE_WRITE_PICKUP   :: Write CD-code pickups (see pkg/cd_code)
+C/\  | | | | |-OBCS_WRITE_PICKUP      :: Write OBCS pickups    (see pkg/obcs)
+C/\  | | | | |-GGL90_WRITE_PICKUP     :: Write GGL90 pickups   (see pkg/ggl90)
+C/\  | | | | |-BBL_WRITE_PICKUP       :: Write BBL pickups     (see pkg/bbl)
+C/\  | | | | |-CHEAPAML_WRITE_PICKUP  :: Write CheapAML pickups (pkg/cheapaml)
+C/\  | | | | |-FLT_WRITE_PICKUP       :: Write Floats pickups  (see pkg/flt)
+C/\  | | | | |-PTRACERS_WRITE_PICKUP  :: Write pTracers pickups (pkg/ptracers)
+C/\  | | | | |-GCHEM_WRITE_PICKUP     :: Write Geo-Chem pickups (see pkg/gchem)
+C/\  | | | | |-SEAICE_WRITE_PICKUP    :: Write SeaIce pickups  (see pkg/seaice)
+C/\  | | | | |-STREAMICE_WRITE_PICKUP :: Write StreamIce pickups (pkg/streamice)
+C/\  | | | | |-SHELFICE_WRITE_PICKUP :: Write ShelfIce pickups (pkg/shelfice)
+C/\  | | | | |-THSICE_WRITE_PICKUP    :: Write ThSIce pickups  (see pkg/thsice)
+C/\  | | | | |-LAND_WRITE_PICKUP      :: Write Land   pickups  (see pkg/land)
+C/\  | | | | |-ATM_PHYS_WRITE_PICKUP  :: Write Atm-Phys pickups (pkg/atm_phys)
+C/\  | | | | |-FIZHI_WRITE_PICKUP     :: Write Fizhi pickups   (see pkg/fizhi)
+C/\  | | | | |-FIZHI_WRITE_VEGTILES   :: Write Fizhi VegTiles  (see pkg/fizhi)
+C/\  | | | | |-FIZHI_WRITE_DATETIME   :: Write Fizhi DateTime  (see pkg/fizhi)
+C/\  | | | | |-CPL_WRITE_PICKUP       :: Write Coupling-Interface pickups
+C/\  | | | | |-MYPACKAGE_WRITE_PICKUP :: Write pkg/mypackage pickups
+C/\  | | | |
+C/\  | | | |-WRITE_PICKUP          :: Write main model pickup files.
+C/\  | | |
+C/\  | | |-AUTODIFF_INADMODE_SET   :: Set/reset some adjoint flags
+C    | |
+C<===|=| **************************
+C<===|=| END MAIN TIMESTEPPING LOOP
+C<===|=| **************************
+C    | |
+C    | |-COST_AVERAGESFIELDS :: Time-averaged Cost function terms (see pkg/cost)
+C    | |-PROFILES_INLOOP     :: ( see pkg/profiles )
+C    | |-COST_FINAL          :: Cost function package (see pkg/cost)
+C    |
+C    |-CTRL_PACK       :: Control vector support package (see pkg/ctrl)
+C    |
+C    |-GRDCHK_MAIN     :: Gradient check package (see pkg/grdchk)
+C    |
+C    |-TIMER_PRINTALL  :: Computational timing summary
+C    |
+C    |-COMM_STATS      :: Summarise inter-proc and inter-thread communication
+C    |                 :: events.
+C \ev
+C
+CEOI
+
+#include "PACKAGES_CONFIG.h"
+#include "CPP_OPTIONS.h"
+#include "AD_CONFIG.h"
+#ifdef ALLOW_AUTODIFF
+# include "AUTODIFF_OPTIONS.h"
+#endif
+#ifdef ALLOW_CTRL
+# include "CTRL_OPTIONS.h"
+#endif
+
+CBOP
+C     !ROUTINE: THE_MODEL_MAIN
+
+C     !INTERFACE:
+      SUBROUTINE THE_MODEL_MAIN(myThid)
+
+C     !DESCRIPTION: \bv
+C     *==========================================================*
+C     | SUBROUTINE THE_MODEL_MAIN
+C     | o Master controlling routine for model using the MITgcm
+C     |   UV parallel wrapper.
+C     *==========================================================*
+C     | THE_MODEL_MAIN is invoked by the MITgcm UV parallel
+C     | wrapper with a single integer argument "myThid". This
+C     | variable identifies the thread number of an instance of
+C     | THE_MODEL_MAIN. Each instance of THE_MODEL_MAIN works
+C     | on a particular region of the models domain and
+C     | synchronises with other instances as necessary. The
+C     | routine has to "understand" the MITgcm parallel
+C     | environment and the numerical algorithm. Editing this
+C     | routine is best done with some knowledge of both aspects.
+C     | Notes
+C     | =====
+C     | C*P* comments indicating place holders for which code is
+C     |      presently being developed.
+C     *==========================================================*
+C     \ev
+
+C     !CALLING SEQUENCE:
+C     THE_MODEL_MAIN()
+C       |
+C       |
+C       |--INITIALISE_FIXED
+C       |   o Set model configuration (fixed arrays)
+C       |     Topography, hydrography, timestep, grid, etc..
+C       |
+C       |--CTRL_UNPACK      o Derivative mode. Unpack control vector.
+C       |
+C       |--ADTHE_MAIN_LOOP  o Main timestepping loop for combined
+C       |                     prognostic and reverse mode integration.
+C       |
+C       |--THE_MAIN_LOOP    o Main timestepping loop for pure prognostic
+C       |                     integration.
+C       |
+C       |--CTRL_PACK        o Derivative mode. Unpack control vector.
+C       |
+C       |--GRDCHK_MAIN      o Gradient check control routine.
+C       |
+C       |--TIMER_PRINTALL   o Print out timing statistics.
+C       |
+C       |--COMM_STATS       o Print out communication statistics.
+
+C     !USES:
+      IMPLICIT NONE
+
+C     == Global variables ===
+#include "SIZE.h"
+#include "EEPARAMS.h"
+#include "PARAMS.h"
+#include "DYNVARS.h"
+
+#ifdef ALLOW_AUTODIFF
+# include "tamc.h"
+#endif
+#ifdef ALLOW_CTRL
+# include "ctrl.h"
+# include "optim.h"
+#endif
+
+C     !INPUT/OUTPUT PARAMETERS:
+C     == Routine arguments ==
+C     myThid :: Thread number for this instance of the routine.
+      INTEGER myThid
+
+C     !LOCAL VARIABLES:
+C     == Local variables ==
+C     Note: Under the multi-threaded model myIter and myTime are local
+C           variables passed around as routine arguments.
+C           Although this is fiddly it saves the need to impose
+C           additional synchronisation points when they are updated.
+C     myTime :: Time counter for this thread
+C     myIter :: Iteration counter for this thread
+      INTEGER myIter
+      _RL     myTime
+      LOGICAL exst
+      LOGICAL lastdiva
+CEOP
+
+C--   set default:
+      exst     = .TRUE.
+      lastdiva = .TRUE.
+
+#ifdef ALLOW_DEBUG
+      IF (debugMode) CALL DEBUG_ENTER('THE_MODEL_MAIN',myThid)
+#endif
+
+#if defined(USE_PAPI) || defined(USE_PCL_FLOPS_SFP) || defined(USE_PCL_FLOPS) || defined(USE_PCL)
+      CALL TIMER_CONTROL('','INIT','THE_MODEL_MAIN',myThid)
+#endif
+C--   This timer encompasses the whole code
+      CALL TIMER_START('ALL                    [THE_MODEL_MAIN]',myThid)
+
+#ifdef ALLOW_DEBUG
+      IF (debugMode) CALL DEBUG_CALL('INITIALISE_FIXED',myThid)
+#endif
+C--   Set model configuration (fixed arrays)
+      CALL TIMER_START('INITIALISE_FIXED       [THE_MODEL_MAIN]',myThid)
+      CALL INITIALISE_FIXED( myThid )
+      CALL TIMER_STOP ('INITIALISE_FIXED       [THE_MODEL_MAIN]',myThid)
+
+      myTime = startTime
+      myIter = nIter0
+
+#if ( defined (ALLOW_ADMTLM) )
+
+      STOP 'should never get here; ADMTLM_DSVD calls ADMTLM_DRIVER'
+
+#elif ( defined (ALLOW_AUTODIFF))
+
+# ifndef EXCLUDE_CTRL_PACK
+      IF ( useCTRL ) THEN
+         inquire( file='costfinal', exist=exst )
+         IF ( .NOT. exst ) THEN
+            IF ( (optimcycle.NE.0 .OR. .NOT.doinitxx)
+     &           .AND. doMainUnpack ) THEN
+               CALL TIMER_START('CTRL_UNPACK   [THE_MODEL_MAIN]',myThid)
+               CALL CTRL_UNPACK( .TRUE. , myThid )
+               CALL TIMER_STOP ('CTRL_UNPACK   [THE_MODEL_MAIN]',myThid)
+            ENDIF
+         ENDIF
+       ENDIF
+# endif /* EXCLUDE_CTRL_PACK */
+
+# ifdef ALLOW_COST
+      CALL COST_DEPENDENT_INIT ( myThid )
+# endif
+
+# if ( defined (ALLOW_TANGENTLINEAR_RUN) )
+
+#  ifdef ALLOW_DEBUG
+      IF (debugMode) CALL DEBUG_CALL('G_THE_MAIN_LOOP',myThid)
+#  endif
+      CALL TIMER_START('G_THE_MAIN_LOOP           [TANGENT RUN]',myThid)
+      CALL G_THE_MAIN_LOOP ( myTime, myIter, myThid )
+      CALL TIMER_STOP ('G_THE_MAIN_LOOP           [TANGENT RUN]',myThid)
+
+# elif ( defined (ALLOW_ADJOINT_RUN) || \
+         defined (ALLOW_ECCO_OPTIMIZATION) )
+
+#  ifdef ALLOW_DIVIDED_ADJOINT
+C-- The following assumes the TAF option '-pure'
+      inquire( file='costfinal', exist=exst )
+      IF ( .NOT. exst) THEN
+#   ifdef ALLOW_DEBUG
+         IF (debugMode) CALL DEBUG_CALL('MDTHE_MAIN_LOOP',myThid)
+#   endif
+         CALL TIMER_START('MDTHE_MAIN_LOOP            [MD RUN]', myThid)
+         CALL MDTHE_MAIN_LOOP ( myTime, myIter, myThid )
+         CALL TIMER_STOP ('MDTHE_MAIN_LOOP            [MD RUN]', myThid)
+         CALL COST_FINAL_STORE ( myThid, lastdiva )
+      ELSE
+#   ifdef ALLOW_DEBUG
+         IF (debugMode) CALL DEBUG_CALL('ADTHE_MAIN_LOOP',myThid)
+#   endif
+         CALL TIMER_START('ADTHE_MAIN_LOOP       [ADJOINT RUN]', myThid)
+         CALL ADTHE_MAIN_LOOP (  myThid )
+         CALL TIMER_STOP ('ADTHE_MAIN_LOOP       [ADJOINT RUN]', myThid)
+         CALL COST_FINAL_RESTORE ( myThid, lastdiva )
+      ENDIF
+
+#  else /* ALLOW_DIVIDED_ADJOINT undef */
+#   ifdef ALLOW_DEBUG
+      IF (debugMode) CALL DEBUG_CALL('ADTHE_MAIN_LOOP',myThid)
+#   endif
+      CALL TIMER_START('ADTHE_MAIN_LOOP          [ADJOINT RUN]', myThid)
+      CALL ADTHE_MAIN_LOOP ( myThid )
+      CALL TIMER_STOP ('ADTHE_MAIN_LOOP          [ADJOINT RUN]', myThid)
+#  endif /* ALLOW_DIVIDED_ADJOINT */
+
+# else /* forward run only within AD setting */
+
+#  ifdef ALLOW_DEBUG
+      IF (debugMode) CALL DEBUG_CALL('THE_MAIN_LOOP',myThid)
+#  endif
+C--   Call time stepping loop of full model
+      CALL TIMER_START('THE_MAIN_LOOP          [THE_MODEL_MAIN]',myThid)
+      CALL THE_MAIN_LOOP( myTime, myIter, myThid )
+      CALL TIMER_STOP ('THE_MAIN_LOOP          [THE_MODEL_MAIN]',myThid)
+
+# endif /* forward run only within AD setting */
+
+# ifndef EXCLUDE_CTRL_PACK
+      IF ( useCTRL ) THEN
+      IF ( lastdiva .AND. doMainPack ) THEN
+         CALL TIMER_START('CTRL_PACK           [THE_MODEL_MAIN]',myThid)
+         CALL CTRL_PACK( .FALSE. , myThid )
+         CALL TIMER_STOP ('CTRL_PACK           [THE_MODEL_MAIN]',myThid)
+         IF ( ( optimcycle.EQ.0 .OR. (.NOT. doMainUnpack) )
+     &        .AND. myIter.EQ.nIter0 ) THEN
+            CALL TIMER_START('CTRL_PACK     [THE_MODEL_MAIN]',myThid)
+            CALL CTRL_PACK( .TRUE. , myThid )
+            CALL TIMER_STOP ('CTRL_PACK     [THE_MODEL_MAIN]',myThid)
+         ENDIF
+      ENDIF
+      ENDIF
+# endif /* EXCLUDE_CTRL_PACK */
+
+# ifdef ALLOW_GRDCHK
+      IF ( useGrdchk .AND. lastdiva ) THEN
+         CALL TIMER_START('GRDCHK_MAIN         [THE_MODEL_MAIN]',myThid)
+         CALL GRDCHK_MAIN( myThid )
+         CALL TIMER_STOP ('GRDCHK_MAIN         [THE_MODEL_MAIN]',myThid)
+      ENDIF
+# endif
+
+#else /* ALL AD-related undef */
+
+# ifdef ALLOW_DEBUG
+      IF (debugMode) CALL DEBUG_CALL('THE_MAIN_LOOP',myThid)
+# endif
+C--   Call time stepping loop of full model
+      CALL TIMER_START('THE_MAIN_LOOP          [THE_MODEL_MAIN]',myThid)
+      CALL THE_MAIN_LOOP( myTime, myIter, myThid )
+      CALL TIMER_STOP ('THE_MAIN_LOOP          [THE_MODEL_MAIN]',myThid)
+
+#endif /* ALLOW_TANGENTLINEAR_RUN ALLOW_ADJOINT_RUN ALLOW_ADMTLM */
+
+#ifdef ALLOW_STREAMICE
+      IF (useStreamIce) THEN
+        CALL STREAMICE_FINALIZE_PETSC
+      ENDIF
+#endif
+
+#ifdef ALLOW_MNC
+      IF (useMNC) THEN
+C       Close all open NetCDF files
+        _BEGIN_MASTER( myThid )
+        CALL MNC_FILE_CLOSE_ALL( myThid )
+        _END_MASTER( myThid )
+      ENDIF
+#endif
+
+C--   This timer encompasses the whole code
+      CALL TIMER_STOP ('ALL                    [THE_MODEL_MAIN]',myThid)
+
+C--   Write timer statistics
+      IF ( myThid .EQ. 1 ) THEN
+       CALL TIMER_PRINTALL( myThid )
+       CALL COMM_STATS
+      ENDIF
+
+C--   Check threads synchronization :
+      CALL BAR_CHECK( 9, myThid )
+
+#ifdef ALLOW_DEBUG
+      IF (debugMode) CALL DEBUG_LEAVE('THE_MODEL_MAIN',myThid)
+#endif
+
+      RETURN
+      END


### PR DESCRIPTION
This pull request enables ECCO V4r4's flux-forced model to restart from a set of pickups, even when the control package is active. Such capability was not available in the V4r4 code base, specifically in MITgcm checkpoint66g, although it has been implemented in more recent MITgcm releases. 

The pickup files are `pickup.0123456789.data`, `pickup_ggl90.0123456789.data`, `pickup_ecco.0123456789.data`, as well as their corresponding meta files (replace the 10-digit number 0123456789 with the restart time-step number). These pickup files can be generated by running the model from `nIter0`=1. In particular, the file `pickup_ecco.0123456789.data` is a new kind of pickup file that was not part of the original V4r4 setup's output. It contains the initial (at `nIter0`=1) global ocean mean volume and density, which are needed to compute the Greatbatch correction when outputting the diagnostic variables `SSH` and `OBP`, among other similar variables. 

A few remaining issues are listed below:

- There is a small difference between a restart and an original non-stop run, but the difference appears minor and unlikely to cause practical concerns. Based on a short one-month restart run, the largest sea level difference observed around the global ocean is less than approximately 1e-7 meters over one month of model integration.
- For the following diagnostic variables: `SSH` and `OBP` (and their variants), the field at the first time step (whether in a restart or a non-stop run) is incorrect, due to some initialization issues (mainly pressure load) in calculating these diagnostics. Since this issue does not affect the actual model state, and fixing it would result in diagnostic variable values throughout the model integration period differing from the official V4r4 release, it has not been corrected. As the issue only affects the first time step, averaging over a longer time period, such as one month, will mitigate its severity.