### PR TITLE
fixed v4r4 ocean velocity native grid groupings. mistakenly had vecto…

### DIFF
--- a/ECCOv4 Release 4/metadata/ECCOv4r4_groupings_for_native_datasets.json
+++ b/ECCOv4 Release 4/metadata/ECCOv4r4_groupings_for_native_datasets.json
@@ -144,16 +144,12 @@
    },
    {
     "name": "ocean velocity",
-    "fields": "EVEL, NVEL, WVELMASS",
+    "fields": "UVEL, VVEL, WVELMASS",
     "product": "native",
     "variable_rename" : "WVELMASS:WVEL",
     "filename" : "OCEAN_VELOCITY",
     "dimension" : "3D",
     "frequency" : "AVG_DAY, AVG_MON",
-    "vector_inputs_old": "UVEL,VVEL:EVEL,NVEL",
-    "vector_inputs": {"UVEL":["EVEL", "NVEL"], "VVEL":["EVEL", "NVEL"]},
-    "vector_outputs_old": "EVEL:EAST,NVEL:NORTH",
-    "vector_outputs": {"EVEL":"EAST", "NVEL":"NORTH"}
    },
    {
     "name": "Gent-McWilliams ocean bolus velocity",


### PR DESCRIPTION
…r transformation information. not needed for native grid granules