### PR TITLE
Fix wrong filename length for m_horflux_vol

### DIFF
--- a/ECCOv4 Release 4/flux-forced/code/ecco_check.F
+++ b/ECCOv4 Release 4/flux-forced/code/ecco_check.F
@@ -511,7 +511,7 @@ c-- (upper/lower-case matters) in cost_gencost_customize
      &          (gencost_barfile(k)(1:13).EQ.'m_boxmean_obp').OR.
      &          (gencost_barfile(k)(1:14).EQ.'m_boxmean_salt').OR.
      &          (gencost_barfile(k)(1:17).EQ.'m_boxmean_ptracer').OR.
-     &          (gencost_barfile(k)(1:14).EQ.'m_horflux_vol')
+     &          (gencost_barfile(k)(1:13).EQ.'m_horflux_vol')
      &        )) then
             using_gencost(k)=.FALSE.
             il=ilnblnk(gencost_barfile(k))


### PR DESCRIPTION
When checking if gencost_barfile is equal to m_horflux_vol, the length of the filename of gencost_barfile should be 1:13, not 1:14. 