### PR TITLE
Add more namelist files for V4r4 flux-forced

### DIFF
--- a/ECCOv4 Release 4/flux-forced/namelist/data.diffkr_total
+++ b/ECCOv4 Release 4/flux-forced/namelist/data.diffkr_total
@@ -1,0 +1,159 @@
+# ====================
+# | Model parameters |
+# ====================
+#
+# Continuous equation parameters
+ &PARM01
+ tRef               = 3*23.,3*22.,21.,2*20.,19.,2*18.,17.,2*16.,15.,14.,13.,
+                      12.,11.,2*9.,8.,7.,2*6.,2*5.,3*4.,3*3.,4*2.,12*1.,
+ sRef               = 50*34.5,
+ no_slip_sides  = .TRUE.,
+ no_slip_bottom = .TRUE.,
+#
+ viscAr=0.5E-4,
+#
+ viscAh=1.E0,
+ viscAhGrid=2.E-2,
+# viscAh=2.0e4,
+#
+ diffKhT=1.E1,
+ diffKrT=1.E-5,
+ diffKhS=1.E1,
+ diffKrS=1.E-5,
+#
+### diffKrBL79surf=0.1E-4,
+### diffKrBL79deep=1.0E-4,
+ bottomDragQuadratic = 0.001,
+#when using ggl90
+ ivdc_kappa=10.,
+ implicitDiffusion=.TRUE.,
+ implicitViscosity=.TRUE.,
+ useRealFreshWaterFlux=.TRUE.,
+# balanceThetaClimRelax=.TRUE.,
+ balanceSaltClimRelax=.TRUE.,
+# balanceEmPmR=.TRUE.,
+# balanceQnet=.TRUE.,
+ allowFreezing=.FALSE.,
+### hFacInf=0.2,
+### hFacSup=2.0,
+ hFacMin=.2,
+ hFacMinDr=5.,
+ select_rStar=2,
+ nonlinFreeSurf=4,
+ gravity=9.81,
+ rhonil=1029.,
+ rhoConst=1029.,
+ rhoConstFresh=1000.,
+ temp_EvPrRn=0.,
+ convertFW2Salt=-1.,
+ eosType='JMD95Z',
+ implicitFreeSurface=.TRUE.,
+ exactConserv=.TRUE.,
+ useSingleCpuIO=.TRUE.,
+ tempAdvScheme=30,
+ saltAdvScheme=30,
+ tempVertAdvScheme=3,
+ saltVertAdvScheme=3,
+ tempImplVertAdv=.TRUE.,
+ saltImplVertAdv=.TRUE.,
+ staggerTimeStep=.TRUE.,
+ vectorInvariantMomentum=.TRUE.,
+#when using the cd scheme:
+# useCDscheme=.TRUE.,
+ useJamartWetPoints=.TRUE.,
+ readBinaryPrec=32,
+ writeBinaryPrec=32,
+ debugLevel=1,
+ /
+
+# Elliptic solver parameters
+ &PARM02
+ cg2dMaxIters=300,
+#cg2dTargetResWunit=1.E-12,
+ /
+
+# Time stepping parameters
+ &PARM03
+ nIter0=1,
+#2 lev2 for testing:
+#nTimeSteps=8,
+#3month
+#nTimeSteps=2160,
+#6month
+#nTimeSteps=4343,
+#18month
+#nTimeSteps=13110,
+#2yr
+#nTimeSteps=17520,
+#10yr
+#nTimeSteps=87647,
+#11yr
+#nTimeSteps=96407,
+#20y:
+#nTimeSteps=175295,
+#22y:
+#nTimeSteps=192839,
+#24y:
+#nTimeSteps=210359,
+#April 30, 2017, 12Z
+#nTimeSteps=222023,
+#26yr
+ nTimeSteps=227903,
+#60 years
+#nTimeSteps=525985,
+#
+ forcing_In_AB=.FALSE.,
+ momDissip_In_AB=.FALSE.,
+#when using the cd scheme:
+# epsAB_CD = 0.25,
+# tauCD=172800.0,
+ deltaTmom   =3600.,
+ deltaTtracer=3600.,
+ deltaTfreesurf=3600.,
+ deltaTClock =3600.,
+#when using ab2:
+# abEps = 0.1,
+#when using ab3:
+ doAB_onGtGs=.FALSE.,
+ alph_AB=0.5,
+ beta_AB=0.281105,
+#
+ pChkptFreq  =31536000.0,
+ chkptFreq   =31536000.0,
+# taveFreq    =31536000.0,
+# dumpFreq    =31536000.0,
+# monitorFreq = 7200.0,
+ monitorFreq = 6307200.0,
+#monitorfreq = 3600.
+ dumpInitAndLast = .TRUE.,
+ adjDumpFreq = 31536000.0,
+#adjDumpFreq = 604800.0,
+ adjMonitorFreq = 864000.0,
+ pickupStrictlyMatch=.FALSE.,
+ /
+
+# Gridding parameters
+ &PARM04
+ usingCurvilinearGrid=.TRUE.,
+ delR = 
+     10.00, 10.00, 10.00, 10.00, 10.00, 10.00, 10.00, 10.01,
+     10.03, 10.11, 10.32, 10.80, 11.76, 13.42, 16.04, 19.82, 24.85,
+     31.10, 38.42, 46.50, 55.00, 63.50, 71.58, 78.90, 85.15, 90.18,
+     93.96, 96.58, 98.25, 99.25,100.01,101.33,104.56,111.33,122.83,
+     139.09,158.94,180.83,203.55,226.50,249.50,272.50,295.50,318.50,
+     341.50,364.50,387.50,410.50,433.50,456.50,
+ /
+
+# Input datasets
+ &PARM05
+ diffKrFile='xx_diffkr.effective.V4r4',
+ adTapeDir='tapes',
+#bathyFile      ='bathy_eccollc_90x50.bin',
+ bathyFile      ='bathy_eccollc_90x50_min2pts.bin',
+ hydrogThetaFile='T_OWPv1_M_eccollc_90x50.bin',
+ hydrogSaltFile ='S_OWPv1_M_eccollc_90x50.bin',
+ viscA4Dfile    ='fenty_biharmonic_visc_v11.bin',
+ viscA4Zfile    ='fenty_biharmonic_visc_v11.bin',
+ geothermalFile='geothermalFlux.bin',
+#
+ /

--- a/ECCOv4 Release 4/flux-forced/namelist/data.gmredi_total
+++ b/ECCOv4 Release 4/flux-forced/namelist/data.gmredi_total
@@ -1,0 +1,39 @@
+# GM+Redi package parameters:
+#     GM_Small_Number  :: epsilon used in computing the slope
+#     GM_slopeSqCutoff :: slope^2 cut-off value 
+
+#-from MOM :
+# GM_background_K: 	G & Mc.W  diffusion coefficient
+# GM_maxSlope    :	max slope of isopycnals
+# GM_Scrit       :	transition for scaling diffusion coefficient
+# GM_Sd          :	half width scaling for diffusion coefficient
+# GM_taper_scheme:	slope clipping or one of the tapering schemes
+# GM_Kmin_horiz  :	horizontal diffusion minimum value 
+
+#-Option parameters (needs to "define" options in GMREDI_OPTIONS.h")
+# GM_isopycK     :	isopycnal diffusion coefficient (default=GM_background_K)
+# GM_AdvForm     :	turn on GM Advective form       (default=Skew flux form)
+
+ &GM_PARM01 
+  GM_Small_Number  = 1.D-20,
+  GM_slopeSqCutoff = 1.D+08,
+  GM_AdvForm         = .TRUE.,
+  GM_isopycK         = 1.D+3,
+  GM_background_K    = 1.D+3,
+  GM_maxSlope        = 4.D-3,
+  GM_taper_scheme    = 'stableGmAdjTap',
+  GM_Kmin_horiz      = 100.,
+  GM_Scrit           = 4.D-3,
+  GM_Sd              = 1.D-3,
+  GM_background_K3dFile='xx_kapgm.effective.V4r4',
+  GM_isopycK3dFile='xx_kapredi.effective.V4r4',
+
+#
+###  GM_Visbeck_alpha   = 1.5D-2,
+###  GM_Visbeck_alpha   = 0.D0,
+###  GM_Visbeck_length  = 2.D+5,
+###  GM_Visbeck_depth   = 1.D+3,
+###  GM_Visbeck_maxval_K= 2.5D+3,
+ /
+
+


### PR DESCRIPTION
Add more namelist files that specify the filenames of ECCO V4r4's total DiffKr, KapGM, and KapRedi fields, with their control adjustments folded in. 