### PR TITLE
Fix incorrect barfile name in flux-forced version of r4

### DIFF
--- a/ECCOv4 Release 4/flux-forced/code/ecco_phys.F
+++ b/ECCOv4 Release 4/flux-forced/code/ecco_phys.F
@@ -382,7 +382,7 @@ c---------
      &        gencost_barfile(kgen)(1:13).EQ.'m_boxmean_obp') then
            if (gencost_barfile(kgen)(1:17).EQ.'m_boxmean_eta_dyn') then
             tmpfld=m_eta_dyn(i,j,bi,bj)
-           else if (gencost_barfile(kgen)(1:13).EQ.'m_boxmean_eta_dyn')
+           else if (gencost_barfile(kgen)(1:13).EQ.'m_boxmean_eta')
      &      then
             tmpfld=m_eta(i,j,bi,bj)
            else if (gencost_barfile(kgen)(1:17).EQ.'m_boxmean_obpgmap')


### PR DESCRIPTION
Fix incorrect barfile name in ecco_phys.F for the flux-forced version of ECCO V4 Release 4.